### PR TITLE
feat(SAPIC-39): GitHub OAuth

### DIFF
--- a/crates/moss-git/src/adapters/auth.rs
+++ b/crates/moss-git/src/adapters/auth.rs
@@ -61,13 +61,14 @@ mod gitlab_tests {
         let repo_path = Path::new("test-repo-lab");
 
         let auth_agent =
-            OAuthAgent::read_from_file().unwrap_or_else(|_| Arc::new(OAuthAgent::github()));
+            OAuthAgent::read_from_file().unwrap_or_else(|_| Arc::new(OAuthAgent::gitlab()));
 
         let repo = RepoHandle::clone(repo_url, repo_path, auth_agent).unwrap();
     }
 
     #[test]
     fn cloning_with_ssh() {
+        dotenv::dotenv().ok();
         let repo_url = &dotenv::var("GITLAB_TEST_REPO_SSH").unwrap();
         let repo_path = Path::new("test-repo-lab");
 

--- a/crates/moss-git/src/models/oauth.rs
+++ b/crates/moss-git/src/models/oauth.rs
@@ -1,40 +1,63 @@
+use crate::models::oauth::OAuthCred::{WithExpiration, WithoutExpiration};
 use serde::{Deserialize, Serialize};
 use std::time::Instant;
-
 // Since `Instant` is opaque and cannot be serialized
 // We will only store the refresh_token when serializing OAuth Credential
 // Forcing refreshing of tokens for new sessions
+
 #[derive(Clone, Serialize, Deserialize)]
-pub struct OAuthCred {
-    #[serde(skip)]
-    access_token: Option<String>,
-    #[serde(skip)]
-    time_to_refresh: Option<Instant>,
-    refresh_token: String,
+pub enum OAuthCred {
+    WithExpiration {
+        #[serde(skip)]
+        access_token: Option<String>,
+        #[serde(skip)]
+        time_to_refresh: Option<Instant>,
+        refresh_token: String,
+    },
+    WithoutExpiration {
+        access_token: String,
+    },
 }
 
 impl OAuthCred {
-    pub fn new(
+    pub fn with_expiration(
         access_token: Option<&str>,
         time_to_refresh: Option<Instant>,
         refresh_token: &str,
-    ) -> OAuthCred {
-        OAuthCred {
+    ) -> Self {
+        WithExpiration {
             access_token: access_token.map(String::from),
             time_to_refresh,
             refresh_token: refresh_token.to_string(),
         }
     }
 
+    pub fn without_expiration(access_token: &str) -> Self {
+        WithoutExpiration {
+            access_token: access_token.to_string(),
+        }
+    }
+
+    pub fn refresh_token(&self) -> Option<String> {
+        match self {
+            OAuthCred::WithExpiration { refresh_token, .. } => Some(refresh_token.clone()),
+            OAuthCred::WithoutExpiration { .. } => None,
+        }
+    }
+
     pub fn access_token(&self) -> Option<String> {
-        self.access_token.clone()
+        match self {
+            OAuthCred::WithExpiration { access_token, .. } => access_token.clone(),
+            OAuthCred::WithoutExpiration { access_token, .. } => Some(access_token.clone()),
+        }
     }
 
     pub fn time_to_refresh(&self) -> Option<Instant> {
-        self.time_to_refresh.clone()
-    }
-
-    pub fn refresh_token(&self) -> String {
-        self.refresh_token.clone()
+        match self {
+            OAuthCred::WithExpiration {
+                time_to_refresh, ..
+            } => time_to_refresh.clone(),
+            OAuthCred::WithoutExpiration { .. } => None,
+        }
     }
 }

--- a/crates/moss-git/src/repo.rs
+++ b/crates/moss-git/src/repo.rs
@@ -281,7 +281,7 @@ mod test {
     use crate::repo::RepoHandle;
     use crate::TestStorage;
 
-    // cargo test test_add_commit_push -- --nocapture
+    // cargo test test_clone_add_commit_push -- --nocapture
     #[test]
     fn test_clone_add_commit_push() {
         // TODO: Support verified signed commits using `gpg`


### PR DESCRIPTION
From now on, we will use plain OAuth App also for GitHub instead of GitHub App, since it provides a smoother user experience.
Add logic to handle OAuth Providers (GitHub) whose access tokens don't expire, for whom no refresh flow is needed.
