### PR TITLE
devops(SAPIC-125): The auto-assign bot shouldn’t trigger if an assignee was already selected

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -6,10 +6,11 @@ on:
   pull_request:
     types: [opened]
 
+
 jobs:
   assign_creator:
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.assignee == null }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0


### PR DESCRIPTION
Test with assigning @g10z3r 