### PR TITLE
fix(SAPIC-150): Support mouse wheel scrolling

### DIFF
--- a/view/desktop/src/lib/moss-tabs/src/dockview/components/titlebar/tabsContainer.ts
+++ b/view/desktop/src/lib/moss-tabs/src/dockview/components/titlebar/tabsContainer.ts
@@ -178,6 +178,8 @@ export class TabsContainer extends CompositeDisposable implements ITabsContainer
 
     this.tabContainer = document.createElement("div");
     this.tabContainer.className = "dv-tabs-container";
+    this.tabContainer.style.overflowX = "auto";
+    this.tabContainer.style.overflowY = "hidden";
 
     this.voidContainer = new VoidContainer(this.accessor, this.group);
 
@@ -241,6 +243,18 @@ export class TabsContainer extends CompositeDisposable implements ITabsContainer
 
         if (isLeftClick) {
           this.accessor.doSetGroupActive(this.group);
+        }
+      }),
+      addDisposableListener(this.tabContainer, "wheel", (event) => {
+        if (event.deltaY !== 0) {
+          if (this.tabContainer.scrollWidth > this.tabContainer.clientWidth) {
+            if (!event.shiftKey) {
+              event.preventDefault();
+
+              const scrollAmount = event.deltaY * 0.7;
+              this.tabContainer.scrollLeft += scrollAmount;
+            }
+          }
         }
       })
     );


### PR DESCRIPTION
Added support mouse wheel scrolling to moss-tabs library:

![image](https://github.com/user-attachments/assets/de659845-5e3f-4e79-826a-49773cb81c03)
