### PR TITLE
fix(SAPIC-173): [Backend] Deserialization error while reading data

### DIFF
--- a/crates/moss-workspace/bindings/types.ts
+++ b/crates/moss-workspace/bindings/types.ts
@@ -17,7 +17,7 @@ export type EditorGridNode =
   | { "type": "branch"; data: Array<EditorGridNode>; size: number }
   | { "type": "leaf"; data: EditorGridLeafData; size: number };
 
-export type EditorGridOrientation = "HORIZONTAL" | "VERTICAL";
+export type EditorGridOrientation = "horizontal" | "vertical";
 
 export type EditorGridState = {
   root: EditorGridNode;

--- a/crates/moss-workspace/src/models/types/editor.rs
+++ b/crates/moss-workspace/src/models/types/editor.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use ts_rs::TS;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, TS)]
-#[serde(rename_all = "UPPERCASE")]
+#[serde(rename_all = "lowercase")]
 #[ts(export, export_to = "types.ts")]
 pub enum EditorGridOrientation {
     Horizontal,


### PR DESCRIPTION
To fix the serialization issue, simply delete the `state.db` file from the `TestWorkspace` folder in the AppFolder. It likely still stores the data in the old serialization format, and deleting it will allow the new format to be regenerated.

Furthermore, now the tabs restoration functionality works as intended. The error is that for `EditorGridOrientation`, the frontend is passing lowercase `vertical` and `horizontal`, but the backend is expecting uppercase. This error makes `set_layout_parts_state` command fail, which means that no data is stored into the database. It also seems to make panels always stacked horizontally. Since there are too many places in the frontend that uses the lowercase spelling, I decided to make the backend accept it as well.