### PR TITLE
feat(SAPIC-294): Database version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ moss_activity_indicator = { path = "crates/moss-activity-indicator" }
 moss_file = { path = "crates/moss-file" }
 async-stream = "0.3.6"
 notify = "8.0"
-redb = "2.5.0"
+redb = "2.6.0"
 tauri = { version = "2.2.5", default-features = false }
 rand = { version = "0.9.0", features = ["thread_rng"] }
 serde = "1.0.217"

--- a/crates/moss-db/src/lib.rs
+++ b/crates/moss-db/src/lib.rs
@@ -5,7 +5,7 @@ pub mod primitives;
 pub use common::*;
 
 use anyhow::Result;
-use redb::{Database, Key, TableDefinition};
+use redb::{Builder, Database, Key, TableDefinition};
 use serde::{Serialize, de::DeserializeOwned};
 use std::{borrow::Borrow, path::Path, sync::Arc};
 use tokio::sync::Notify;
@@ -43,7 +43,9 @@ where
 impl ReDbClient {
     pub fn new(path: impl AsRef<Path>) -> Result<Self> {
         // Using compact() on an empty ReDb database will shrink its file size by 1 mb
-        let mut database = Database::create(path)?;
+        let mut database = Builder::new()
+            .create_with_file_format_v3(true)
+            .create(path)?;
         database.compact()?;
         Ok(Self {
             db: Arc::new(database),


### PR DESCRIPTION
Upgrading `redb` to v2.6.0, and start using v3 file format, which will become the only accepted format for redb when v3.0 comes. You will need to delete all `.db` files from the `.sapic` folder