### PR TITLE
Fix argon2 options in moss_db

### DIFF
--- a/crates/moss-db/src/encrypted_bincode_table.rs
+++ b/crates/moss-db/src/encrypted_bincode_table.rs
@@ -107,7 +107,15 @@ where
         let salt = SaltString::encode_b64(salt)
             .map_err(|e| DatabaseError::Internal(format!("Failed to encode salt: {}", e)))?;
 
-        let argon2 = Argon2::default();
+        let params = argon2::ParamsBuilder::new()
+            .m_cost(self.options.memory_cost)
+            .t_cost(self.options.time_cost)
+            .p_cost(self.options.parallelism)
+            .output_len(32)
+            .build()
+            .map_err(|e| DatabaseError::Internal(format!("Failed to build Argon2 params: {}", e)))?;
+
+        let argon2 = Argon2::new(argon2::Algorithm::default(), argon2::Version::default(), params);
         let password_hash = argon2
             .hash_password(password, &salt)
             .map_err(|e| DatabaseError::Internal(format!("Failed to hash password: {}", e)))?;


### PR DESCRIPTION
## Summary
- respect `EncryptionOptions` in `derive_key`

## Testing
- `cargo check -p moss_db`
- `cargo test -p moss_db`


------
https://chatgpt.com/codex/tasks/task_e_684078c30534832fb8f204aaf109c6d4