### PR TITLE
devops(SAPIC-300): Updating Dependabot settings

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,9 @@
 @g10z3r @jevgenis33
+
+.github/workflows/* @brutusyhy @g10z3r @jevgenis33
+
+**/Cargo.toml      @brutusyhy
+**/Cargo.lock      @brutusyhy
+
+**/package.json    @Enthceph @jevgenis33
+**/pnpm-lock.yaml  @Enthceph @jevgenis33

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,13 +13,10 @@ updates:
           - "patch"
     ignore:
       - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+        update-types: [ "version-update:semver-patch" ]
     commit-message:
       prefix: ci
       include: scope
-    reviewers:
-      - g10z3r
-      - jevgenis33
     open-pull-requests-limit: 5
 
   - package-ecosystem: "cargo"
@@ -35,12 +32,10 @@ updates:
           - "patch"
     ignore:
       - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+        update-types: [ "version-update:semver-patch" ]
     commit-message:
       prefix: build(rust)
       prefix-development: chore(rust)
-    reviewers:
-      - brutusyhy
     labels:
       - dependencies
       - rust
@@ -80,13 +75,10 @@ updates:
           - "patch"
     ignore:
       - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+        update-types: [ "version-update:semver-patch" ]
     commit-message:
       prefix: build(typescript)
       prefix-development: chore(typescript)
-    reviewers:
-      - Enthceph
-      - jevgenis33
     labels:
       - dependencies
       - typescript


### PR DESCRIPTION
The `reviewer` setting in `dependabot.yml` is officially deprecated, and have to be replaced by CODEOWNERS