### PR TITLE
Fix CSS variable formatting in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,7 @@ gen-bindings: \
 export-css-variables:
 	@cd $(SCRIPTS_DIR) && $(UV) run css_variables_exporter.py --source ../assets/themes/light.css \
 														   --dest ../packages/config-eslint/moss-lint-plugin/css_variables.json
+	@$(PNPM) prettier --plugin=prettier-plugin-tailwindcss --write packages/config-eslint/moss-lint-plugin/css_variables.json
 
 ## Count Lines of Code
 .PHONY: loc


### PR DESCRIPTION
## Summary
- run Prettier on exported CSS variables in the Makefile

## Testing
- `pnpm lint`
- `pnpm test -- --run` *(fails: Test failed. See above for more details)*

------
https://chatgpt.com/codex/tasks/task_e_6847b3bd771c832f8045848aa7c35ccc