### PR TITLE
refactor(SAPIC-298): Introducing the AnyValue enum into the workspace and workbench crates

### DIFF
--- a/crates/moss-db/src/primitives.rs
+++ b/crates/moss-db/src/primitives.rs
@@ -1,5 +1,4 @@
 use redb::{Key, TypeName, Value};
-use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use std::{fmt::Debug, hash::Hash};
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
@@ -61,76 +60,6 @@ impl Value for AnyKey {
 }
 
 impl Key for AnyKey {
-    fn compare(data1: &[u8], data2: &[u8]) -> std::cmp::Ordering {
-        data1.cmp(data2)
-    }
-}
-
-#[derive(Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize)]
-pub struct AnyValue(Vec<u8>);
-
-impl AnyValue {
-    pub fn new(value: impl Into<Vec<u8>>) -> Self {
-        Self(value.into())
-    }
-
-    pub fn as_bytes(&self) -> &[u8] {
-        &self.0
-    }
-
-    pub fn serialize<T: Serialize>(value: &T) -> Result<Self, serde_json::Error> {
-        serde_json::to_vec(value).map(AnyValue)
-    }
-
-    pub fn deserialize<T: DeserializeOwned>(&self) -> Result<T, serde_json::Error> {
-        serde_json::from_slice(&self.0)
-    }
-}
-
-impl std::borrow::Borrow<[u8]> for AnyValue {
-    fn borrow(&self) -> &[u8] {
-        &self.0
-    }
-}
-
-impl std::fmt::Display for AnyValue {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", String::from_utf8_lossy(&self.0))
-    }
-}
-
-impl Value for AnyValue {
-    type SelfType<'a>
-        = AnyValue
-    where
-        Self: 'a;
-
-    type AsBytes<'a>
-        = &'a [u8]
-    where
-        Self: 'a;
-
-    fn fixed_width() -> Option<usize> {
-        None
-    }
-
-    fn type_name() -> TypeName {
-        TypeName::new("AnyValue")
-    }
-
-    fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Self::AsBytes<'a> {
-        &value.0
-    }
-
-    fn from_bytes<'a>(data: &'a [u8]) -> Self::SelfType<'a>
-    where
-        Self: 'a,
-    {
-        AnyValue(data.to_vec())
-    }
-}
-
-impl Key for AnyValue {
     fn compare(data1: &[u8], data2: &[u8]) -> std::cmp::Ordering {
         data1.cmp(data2)
     }

--- a/crates/moss-storage/src/storage.rs
+++ b/crates/moss-storage/src/storage.rs
@@ -1,6 +1,8 @@
 pub mod operations;
 
-use moss_db::{DatabaseResult, Transaction, bincode_table::BincodeTable, primitives::AnyValue};
+use moss_db::{
+    DatabaseResult, Transaction, anyvalue_enum::AnyValueEnum, bincode_table::BincodeTable,
+};
 use serde_json::Value as JsonValue;
 use std::{any::TypeId, collections::HashMap};
 
@@ -16,7 +18,7 @@ pub trait Storage {
 }
 
 pub type StoreTypeId = TypeId;
-pub type SegBinTable = BincodeTable<'static, SegKeyBuf, AnyValue>;
+pub type SegBinTable = BincodeTable<'static, SegKeyBuf, AnyValueEnum>;
 
 #[cfg(test)]
 mod tests {
@@ -46,9 +48,9 @@ mod tests {
         let key2 = SegKey::new("2").to_segkey_buf();
         let key3 = SegKey::new("3").to_segkey_buf();
 
-        let value1 = AnyValue::serialize(&"1".to_string()).unwrap();
-        let value2 = AnyValue::serialize(&2).unwrap();
-        let value3 = AnyValue::serialize(&test_data).unwrap();
+        let value1 = AnyValueEnum::from("1".to_string());
+        let value2 = AnyValueEnum::from(2);
+        let value3 = AnyValueEnum::serialize(&test_data).unwrap();
 
         PutItem::put(store.as_ref(), key1, value1.clone()).unwrap();
         PutItem::put(store.as_ref(), key2, value2.clone()).unwrap();
@@ -60,8 +62,9 @@ mod tests {
         assert_eq!(dumped.len(), 2);
 
         let items_dump = dumped.get("table:items").unwrap();
-        assert_eq!(items_dump["1"], JsonValue::String("1".to_string()));
-        assert_eq!(items_dump["2"], JsonValue::Number(2.into()));
-        assert_eq!(items_dump["3"], serde_json::to_value(&test_data).unwrap());
+        assert_eq!(items_dump["1"], serde_json::to_value(&value1).unwrap());
+        assert_eq!(items_dump["2"], serde_json::to_value(&value2).unwrap());
+        assert_eq!(items_dump["3"], serde_json::to_value(&value3).unwrap());
+        dbg!(items_dump);
     }
 }

--- a/crates/moss-storage/src/storages/collection_storage.rs
+++ b/crates/moss-storage/src/storages/collection_storage.rs
@@ -1,6 +1,6 @@
 use moss_db::{
-    DatabaseClient, DatabaseResult, ReDbClient, Table, Transaction, bincode_table::BincodeTable,
-    primitives::AnyValue,
+    DatabaseClient, DatabaseResult, ReDbClient, Table, Transaction, anyvalue_enum::AnyValueEnum,
+    bincode_table::BincodeTable,
 };
 use redb::TableHandle;
 use serde_json::{Value as JsonValue, json};
@@ -20,8 +20,8 @@ pub mod entities;
 pub mod stores;
 
 const DB_NAME: &str = "state.db";
-pub const TABLE_VARIABLES: BincodeTable<SegKeyBuf, AnyValue> = BincodeTable::new("variables");
-pub const TABLE_UNITS: BincodeTable<SegKeyBuf, AnyValue> = BincodeTable::new("units");
+pub const TABLE_VARIABLES: BincodeTable<SegKeyBuf, AnyValueEnum> = BincodeTable::new("variables");
+pub const TABLE_UNITS: BincodeTable<SegKeyBuf, AnyValueEnum> = BincodeTable::new("units");
 
 pub struct CollectionStorageImpl {
     client: ReDbClient,
@@ -53,10 +53,7 @@ impl Storage for CollectionStorageImpl {
             let name = table.table_definition().name().to_string();
             let mut table_entries = HashMap::new();
             for (k, v) in table.scan(&read_txn)? {
-                table_entries.insert(
-                    k.to_string(),
-                    serde_json::from_slice::<JsonValue>(v.as_bytes())?,
-                );
+                table_entries.insert(k.to_string(), serde_json::to_value(&v)?);
             }
             result.insert(format!("table:{}", name), json!(table_entries));
         }

--- a/crates/moss-storage/src/storages/global_storage.rs
+++ b/crates/moss-storage/src/storages/global_storage.rs
@@ -1,6 +1,6 @@
 use moss_db::{
-    DatabaseClient, DatabaseResult, ReDbClient, Table, Transaction, bincode_table::BincodeTable,
-    primitives::AnyValue,
+    DatabaseClient, DatabaseResult, ReDbClient, Table, Transaction, anyvalue_enum::AnyValueEnum,
+    bincode_table::BincodeTable,
 };
 use redb::TableHandle;
 use serde_json::{Value as JsonValue, json};
@@ -16,7 +16,7 @@ use crate::{
 pub mod entities;
 pub mod stores;
 
-pub const TABLE_ITEMS: BincodeTable<SegKeyBuf, AnyValue> = BincodeTable::new("items");
+pub const TABLE_ITEMS: BincodeTable<SegKeyBuf, AnyValueEnum> = BincodeTable::new("items");
 pub struct GlobalStorageImpl {
     client: ReDbClient,
     tables: HashMap<StoreTypeId, Arc<SegBinTable>>,
@@ -46,10 +46,7 @@ impl Storage for GlobalStorageImpl {
             let name = table.table_definition().name().to_string();
             let mut table_entries = HashMap::new();
             for (k, v) in table.scan(&read_txn)? {
-                table_entries.insert(
-                    k.to_string(),
-                    serde_json::from_slice::<JsonValue>(v.as_bytes())?,
-                );
+                table_entries.insert(k.to_string(), serde_json::to_value(&v)?);
             }
             result.insert(format!("table:{}", name), json!(table_entries));
         }

--- a/crates/moss-storage/src/storages/global_storage/stores.rs
+++ b/crates/moss-storage/src/storages/global_storage/stores.rs
@@ -1,4 +1,4 @@
-use moss_db::primitives::AnyValue;
+use moss_db::anyvalue_enum::AnyValueEnum;
 
 use crate::{
     primitives::segkey::SegKeyBuf,
@@ -11,14 +11,14 @@ use crate::{
 pub mod item_store;
 
 pub trait GlobalItemStore:
-    ListByPrefix<Key = SegKeyBuf, Entity = AnyValue>
-    + TransactionalListByPrefix<Key = SegKeyBuf, Entity = AnyValue>
-    + PutItem<Key = SegKeyBuf, Entity = AnyValue>
-    + TransactionalPutItem<Key = SegKeyBuf, Entity = AnyValue>
-    + RemoveItem<Key = SegKeyBuf, Entity = AnyValue>
-    + TransactionalRemoveItem<Key = SegKeyBuf, Entity = AnyValue>
-    + GetItem<Key = SegKeyBuf, Entity = AnyValue>
-    + TransactionalGetItem<Key = SegKeyBuf, Entity = AnyValue>
+    ListByPrefix<Key = SegKeyBuf, Entity = AnyValueEnum>
+    + TransactionalListByPrefix<Key = SegKeyBuf, Entity = AnyValueEnum>
+    + PutItem<Key = SegKeyBuf, Entity = AnyValueEnum>
+    + TransactionalPutItem<Key = SegKeyBuf, Entity = AnyValueEnum>
+    + RemoveItem<Key = SegKeyBuf, Entity = AnyValueEnum>
+    + TransactionalRemoveItem<Key = SegKeyBuf, Entity = AnyValueEnum>
+    + GetItem<Key = SegKeyBuf, Entity = AnyValueEnum>
+    + TransactionalGetItem<Key = SegKeyBuf, Entity = AnyValueEnum>
     + Send
     + Sync
 {

--- a/crates/moss-storage/src/storages/global_storage/stores/item_store.rs
+++ b/crates/moss-storage/src/storages/global_storage/stores/item_store.rs
@@ -1,4 +1,6 @@
-use moss_db::{DatabaseClient, DatabaseResult, ReDbClient, Transaction, primitives::AnyValue};
+use moss_db::{
+    DatabaseClient, DatabaseResult, ReDbClient, Transaction, anyvalue_enum::AnyValueEnum,
+};
 use std::sync::Arc;
 
 use crate::{
@@ -26,7 +28,7 @@ impl GlobalItemStoreImpl {
 
 impl ListByPrefix for GlobalItemStoreImpl {
     type Key = SegKeyBuf;
-    type Entity = AnyValue;
+    type Entity = AnyValueEnum;
 
     fn list_by_prefix(&self, prefix: &str) -> DatabaseResult<Vec<(Self::Key, Self::Entity)>> {
         let read_txn = self.client.begin_read()?;
@@ -36,7 +38,7 @@ impl ListByPrefix for GlobalItemStoreImpl {
 
 impl TransactionalListByPrefix for GlobalItemStoreImpl {
     type Key = SegKeyBuf;
-    type Entity = AnyValue;
+    type Entity = AnyValueEnum;
 
     fn list_by_prefix(
         &self,
@@ -49,7 +51,7 @@ impl TransactionalListByPrefix for GlobalItemStoreImpl {
 
 impl PutItem for GlobalItemStoreImpl {
     type Key = SegKeyBuf;
-    type Entity = AnyValue;
+    type Entity = AnyValueEnum;
 
     fn put(&self, key: Self::Key, entity: Self::Entity) -> DatabaseResult<()> {
         let mut txn = self.client.begin_write()?;
@@ -60,7 +62,7 @@ impl PutItem for GlobalItemStoreImpl {
 
 impl TransactionalPutItem for GlobalItemStoreImpl {
     type Key = SegKeyBuf;
-    type Entity = AnyValue;
+    type Entity = AnyValueEnum;
 
     fn put(
         &self,
@@ -73,7 +75,7 @@ impl TransactionalPutItem for GlobalItemStoreImpl {
 }
 impl RemoveItem for GlobalItemStoreImpl {
     type Key = SegKeyBuf;
-    type Entity = AnyValue;
+    type Entity = AnyValueEnum;
 
     fn remove(&self, key: Self::Key) -> DatabaseResult<Self::Entity> {
         let mut txn = self.client.begin_write()?;
@@ -85,7 +87,7 @@ impl RemoveItem for GlobalItemStoreImpl {
 
 impl TransactionalRemoveItem for GlobalItemStoreImpl {
     type Key = SegKeyBuf;
-    type Entity = AnyValue;
+    type Entity = AnyValueEnum;
 
     fn remove(&self, txn: &mut Transaction, key: Self::Key) -> DatabaseResult<Self::Entity> {
         self.table.remove(txn, key)
@@ -94,7 +96,7 @@ impl TransactionalRemoveItem for GlobalItemStoreImpl {
 
 impl GetItem for GlobalItemStoreImpl {
     type Key = SegKeyBuf;
-    type Entity = AnyValue;
+    type Entity = AnyValueEnum;
 
     fn get(&self, key: Self::Key) -> DatabaseResult<Self::Entity> {
         let read_txn = self.client.begin_read()?;
@@ -104,7 +106,7 @@ impl GetItem for GlobalItemStoreImpl {
 
 impl TransactionalGetItem for GlobalItemStoreImpl {
     type Key = SegKeyBuf;
-    type Entity = AnyValue;
+    type Entity = AnyValueEnum;
 
     fn get(&self, txn: &Transaction, key: Self::Key) -> DatabaseResult<Self::Entity> {
         self.table.read(&txn, key)

--- a/crates/moss-storage/src/storages/workspace_storage.rs
+++ b/crates/moss-storage/src/storages/workspace_storage.rs
@@ -1,6 +1,6 @@
 use moss_db::{
-    DatabaseClient, DatabaseResult, ReDbClient, Table, Transaction, bincode_table::BincodeTable,
-    primitives::AnyValue,
+    DatabaseClient, DatabaseResult, ReDbClient, Table, Transaction, anyvalue_enum::AnyValueEnum,
+    bincode_table::BincodeTable,
 };
 use redb::TableHandle;
 use serde_json::{Value as JsonValue, json};
@@ -20,8 +20,8 @@ pub mod entities;
 pub mod stores;
 
 const DB_NAME: &str = "state.db";
-pub const TABLE_VARIABLES: BincodeTable<SegKeyBuf, AnyValue> = BincodeTable::new("variables");
-pub const TABLE_ITEMS: BincodeTable<SegKeyBuf, AnyValue> = BincodeTable::new("items");
+pub const TABLE_VARIABLES: BincodeTable<SegKeyBuf, AnyValueEnum> = BincodeTable::new("variables");
+pub const TABLE_ITEMS: BincodeTable<SegKeyBuf, AnyValueEnum> = BincodeTable::new("items");
 
 pub struct WorkspaceStorageImpl {
     client: ReDbClient,
@@ -53,10 +53,7 @@ impl Storage for WorkspaceStorageImpl {
             let name = table.table_definition().name().to_string();
             let mut table_entries = HashMap::new();
             for (k, v) in table.scan(&read_txn)? {
-                table_entries.insert(
-                    k.to_string(),
-                    serde_json::from_slice::<JsonValue>(v.as_bytes())?,
-                );
+                table_entries.insert(k.to_string(), serde_json::to_value(v)?);
             }
             result.insert(format!("table:{}", name), json!(table_entries));
         }

--- a/crates/moss-storage/src/storages/workspace_storage/stores.rs
+++ b/crates/moss-storage/src/storages/workspace_storage/stores.rs
@@ -1,4 +1,4 @@
-use moss_db::primitives::AnyValue;
+use moss_db::anyvalue_enum::AnyValueEnum;
 
 use crate::{
     primitives::segkey::SegKeyBuf,
@@ -13,14 +13,14 @@ pub mod variable_store;
 
 pub trait WorkspaceVariableStore: Send + Sync {}
 pub trait WorkspaceItemStore:
-    ListByPrefix<Key = SegKeyBuf, Entity = AnyValue>
-    + TransactionalListByPrefix<Key = SegKeyBuf, Entity = AnyValue>
-    + PutItem<Key = SegKeyBuf, Entity = AnyValue>
-    + TransactionalPutItem<Key = SegKeyBuf, Entity = AnyValue>
-    + GetItem<Key = SegKeyBuf, Entity = AnyValue>
-    + TransactionalGetItem<Key = SegKeyBuf, Entity = AnyValue>
-    + RemoveItem<Key = SegKeyBuf, Entity = AnyValue>
-    + TransactionalRemoveItem<Key = SegKeyBuf, Entity = AnyValue>
+    ListByPrefix<Key = SegKeyBuf, Entity = AnyValueEnum>
+    + TransactionalListByPrefix<Key = SegKeyBuf, Entity = AnyValueEnum>
+    + PutItem<Key = SegKeyBuf, Entity = AnyValueEnum>
+    + TransactionalPutItem<Key = SegKeyBuf, Entity = AnyValueEnum>
+    + GetItem<Key = SegKeyBuf, Entity = AnyValueEnum>
+    + TransactionalGetItem<Key = SegKeyBuf, Entity = AnyValueEnum>
+    + RemoveItem<Key = SegKeyBuf, Entity = AnyValueEnum>
+    + TransactionalRemoveItem<Key = SegKeyBuf, Entity = AnyValueEnum>
     + Send
     + Sync
 {

--- a/crates/moss-storage/src/storages/workspace_storage/stores/item_store.rs
+++ b/crates/moss-storage/src/storages/workspace_storage/stores/item_store.rs
@@ -1,4 +1,6 @@
-use moss_db::{DatabaseClient, DatabaseResult, ReDbClient, Transaction, primitives::AnyValue};
+use moss_db::{
+    DatabaseClient, DatabaseResult, ReDbClient, Transaction, anyvalue_enum::AnyValueEnum,
+};
 use std::sync::Arc;
 
 use crate::{
@@ -26,7 +28,7 @@ impl WorkspaceItemStoreImpl {
 
 impl ListByPrefix for WorkspaceItemStoreImpl {
     type Key = SegKeyBuf;
-    type Entity = AnyValue;
+    type Entity = AnyValueEnum;
 
     fn list_by_prefix(&self, prefix: &str) -> DatabaseResult<Vec<(Self::Key, Self::Entity)>> {
         let read_txn = self.client.begin_read()?;
@@ -36,7 +38,7 @@ impl ListByPrefix for WorkspaceItemStoreImpl {
 
 impl TransactionalListByPrefix for WorkspaceItemStoreImpl {
     type Key = SegKeyBuf;
-    type Entity = AnyValue;
+    type Entity = AnyValueEnum;
 
     fn list_by_prefix(
         &self,
@@ -49,7 +51,7 @@ impl TransactionalListByPrefix for WorkspaceItemStoreImpl {
 
 impl PutItem for WorkspaceItemStoreImpl {
     type Key = SegKeyBuf;
-    type Entity = AnyValue;
+    type Entity = AnyValueEnum;
 
     fn put(&self, key: Self::Key, entity: Self::Entity) -> DatabaseResult<()> {
         let mut write_txn = self.client.begin_write()?;
@@ -60,7 +62,7 @@ impl PutItem for WorkspaceItemStoreImpl {
 
 impl TransactionalPutItem for WorkspaceItemStoreImpl {
     type Key = SegKeyBuf;
-    type Entity = AnyValue;
+    type Entity = AnyValueEnum;
 
     fn put(
         &self,
@@ -74,7 +76,7 @@ impl TransactionalPutItem for WorkspaceItemStoreImpl {
 
 impl GetItem for WorkspaceItemStoreImpl {
     type Key = SegKeyBuf;
-    type Entity = AnyValue;
+    type Entity = AnyValueEnum;
 
     fn get(&self, key: Self::Key) -> DatabaseResult<Self::Entity> {
         let read_txn = self.client.begin_read()?;
@@ -84,7 +86,7 @@ impl GetItem for WorkspaceItemStoreImpl {
 
 impl TransactionalGetItem for WorkspaceItemStoreImpl {
     type Key = SegKeyBuf;
-    type Entity = AnyValue;
+    type Entity = AnyValueEnum;
 
     fn get(&self, txn: &Transaction, key: Self::Key) -> DatabaseResult<Self::Entity> {
         self.table.read(txn, key)
@@ -93,7 +95,7 @@ impl TransactionalGetItem for WorkspaceItemStoreImpl {
 
 impl RemoveItem for WorkspaceItemStoreImpl {
     type Key = SegKeyBuf;
-    type Entity = AnyValue;
+    type Entity = AnyValueEnum;
 
     fn remove(&self, key: Self::Key) -> DatabaseResult<Self::Entity> {
         let mut write_txn = self.client.begin_write()?;
@@ -105,7 +107,7 @@ impl RemoveItem for WorkspaceItemStoreImpl {
 
 impl TransactionalRemoveItem for WorkspaceItemStoreImpl {
     type Key = SegKeyBuf;
-    type Entity = AnyValue;
+    type Entity = AnyValueEnum;
 
     fn remove(&self, txn: &mut Transaction, key: Self::Key) -> DatabaseResult<Self::Entity> {
         self.table.remove(txn, key)

--- a/crates/moss-workbench/src/api/create_workspace.rs
+++ b/crates/moss-workbench/src/api/create_workspace.rs
@@ -1,7 +1,7 @@
 use anyhow::Context as _;
 use chrono::Utc;
 use moss_common::api::{OperationError, OperationResult, OperationResultExt};
-use moss_db::primitives::AnyValue;
+use moss_db::anyvalue_enum::AnyValueEnum;
 use moss_storage::{global_storage::entities::WorkspaceInfoEntity, storage::operations::PutItem};
 use moss_workspace::{Workspace, workspace::CreateParams};
 use std::{
@@ -82,7 +82,7 @@ impl<R: TauriRuntime> Workbench<R> {
 
                 let item_store = self.global_storage.item_store();
                 let segkey = WORKSPACE_SEGKEY.join(id_str);
-                let value = AnyValue::serialize(&WorkspaceInfoEntity { last_opened_at })?;
+                let value = AnyValueEnum::serialize(&WorkspaceInfoEntity { last_opened_at })?;
                 PutItem::put(item_store.as_ref(), segkey, value)?;
             }
             _ => {}

--- a/crates/moss-workbench/src/api/open_workspace.rs
+++ b/crates/moss-workbench/src/api/open_workspace.rs
@@ -1,6 +1,6 @@
 use chrono::Utc;
 use moss_common::api::{OperationError, OperationResult};
-use moss_db::primitives::AnyValue;
+use moss_db::anyvalue_enum::AnyValueEnum;
 use moss_storage::{global_storage::entities::WorkspaceInfoEntity, storage::operations::PutItem};
 use moss_workspace::Workspace;
 use std::sync::Arc;
@@ -74,7 +74,7 @@ impl<R: TauriRuntime> Workbench<R> {
             let id_str = descriptor.id.to_string();
             let item_store = self.global_storage.item_store();
             let segkey = WORKSPACE_SEGKEY.join(id_str);
-            let value = AnyValue::serialize(&WorkspaceInfoEntity { last_opened_at })?;
+            let value = AnyValueEnum::serialize(&WorkspaceInfoEntity { last_opened_at })?;
             PutItem::put(item_store.as_ref(), segkey, value)?;
         }
 

--- a/crates/moss-workspace/src/api/create_collection.rs
+++ b/crates/moss-workspace/src/api/create_collection.rs
@@ -1,7 +1,7 @@
 use anyhow::Context as _;
 use moss_collection::collection::{self, Collection};
 use moss_common::api::{OperationError, OperationResult};
-use moss_db::primitives::AnyValue;
+use moss_db::anyvalue_enum::AnyValueEnum;
 use moss_storage::{
     storage::operations::PutItem,
     workspace_storage::entities::collection_store_entities::CollectionCacheEntity,
@@ -80,7 +80,7 @@ impl<R: TauriRuntime> Workspace<R> {
 
         {
             let key = COLLECTION_SEGKEY.join(&id_str);
-            let value = AnyValue::serialize(&CollectionCacheEntity {
+            let value = AnyValueEnum::serialize(&CollectionCacheEntity {
                 order: order.clone(),
                 external_abs_path: None,
             })?;

--- a/crates/moss-workspace/src/api/update_state.rs
+++ b/crates/moss-workspace/src/api/update_state.rs
@@ -1,13 +1,12 @@
-use std::collections::HashMap;
-
 use moss_common::api::OperationResult;
-use moss_db::primitives::AnyValue;
+use moss_db::anyvalue_enum::AnyValueEnum;
 use moss_storage::{
     storage::operations::TransactionalPutItem,
     workspace_storage::entities::state_store_entities::{
         EditorGridStateEntity, EditorPanelStateEntity,
     },
 };
+use std::collections::HashMap;
 use tauri::Runtime as TauriRuntime;
 
 use crate::{
@@ -47,7 +46,7 @@ impl<R: TauriRuntime> Workspace<R> {
         let item_store = self.storage.item_store();
         let mut txn = self.storage.begin_write()?;
 
-        let value = AnyValue::serialize(&EditorGridStateEntity::from(part_state.grid))?;
+        let value = AnyValueEnum::serialize(&EditorGridStateEntity::from(part_state.grid))?;
         dbg!(&value);
         TransactionalPutItem::put(
             item_store.as_ref(),
@@ -56,7 +55,7 @@ impl<R: TauriRuntime> Workspace<R> {
             value,
         )?;
 
-        let value = AnyValue::serialize::<HashMap<String, EditorPanelStateEntity>>(
+        let value = AnyValueEnum::serialize::<HashMap<String, EditorPanelStateEntity>>(
             &part_state
                 .panels
                 .into_iter()
@@ -70,7 +69,7 @@ impl<R: TauriRuntime> Workspace<R> {
             value,
         )?;
 
-        let value = AnyValue::serialize(&part_state.active_group)?;
+        let value = AnyValueEnum::serialize(&part_state.active_group)?;
         TransactionalPutItem::put(
             item_store.as_ref(),
             &mut txn,
@@ -85,7 +84,7 @@ impl<R: TauriRuntime> Workspace<R> {
         let item_store = self.storage.item_store();
         let mut txn = self.storage.begin_write()?;
 
-        let value = AnyValue::serialize(&part_state.position)?;
+        let value = AnyValueEnum::serialize(&part_state.position)?;
         TransactionalPutItem::put(
             item_store.as_ref(),
             &mut txn,
@@ -93,7 +92,7 @@ impl<R: TauriRuntime> Workspace<R> {
             value,
         )?;
 
-        let value = AnyValue::serialize(&part_state.size)?;
+        let value = AnyValueEnum::serialize(&part_state.size)?;
         TransactionalPutItem::put(
             item_store.as_ref(),
             &mut txn,
@@ -101,7 +100,7 @@ impl<R: TauriRuntime> Workspace<R> {
             value,
         )?;
 
-        let value = AnyValue::serialize(&part_state.visible)?;
+        let value = AnyValueEnum::serialize(&part_state.visible)?;
         TransactionalPutItem::put(
             item_store.as_ref(),
             &mut txn,
@@ -116,7 +115,7 @@ impl<R: TauriRuntime> Workspace<R> {
         let item_store = self.storage.item_store();
         let mut txn = self.storage.begin_write()?;
 
-        let value = AnyValue::serialize(&part_state.visible)?;
+        let value = AnyValueEnum::serialize(&part_state.visible)?;
         TransactionalPutItem::put(
             item_store.as_ref(),
             &mut txn,
@@ -124,7 +123,7 @@ impl<R: TauriRuntime> Workspace<R> {
             value,
         )?;
 
-        let value = AnyValue::serialize(&part_state.size)?;
+        let value = AnyValueEnum::serialize(&part_state.size)?;
         TransactionalPutItem::put(
             item_store.as_ref(),
             &mut txn,
@@ -142,7 +141,7 @@ impl<R: TauriRuntime> Workspace<R> {
         let item_store = self.storage.item_store();
         let mut txn = self.storage.begin_write()?;
 
-        let value = AnyValue::serialize(&part_state.last_active_container_id)?;
+        let value = AnyValueEnum::serialize(&part_state.last_active_container_id)?;
         TransactionalPutItem::put(
             item_store.as_ref(),
             &mut txn,
@@ -150,7 +149,7 @@ impl<R: TauriRuntime> Workspace<R> {
             value,
         )?;
 
-        let value = AnyValue::serialize(&part_state.position)?;
+        let value = AnyValueEnum::serialize(&part_state.position)?;
         TransactionalPutItem::put(
             item_store.as_ref(),
             &mut txn,

--- a/crates/moss-workspace/src/layout.rs
+++ b/crates/moss-workspace/src/layout.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use moss_db::{Transaction, primitives::AnyValue};
+use moss_db::{Transaction, anyvalue_enum::AnyValueEnum};
 use moss_storage::{
     WorkspaceStorage,
     primitives::segkey::SegKeyBuf,
@@ -157,7 +157,7 @@ impl LayoutService {
         )?
         .into_iter()
         .map(|(segkey, value)| (segkey, value))
-        .collect::<HashMap<SegKeyBuf, AnyValue>>();
+        .collect::<HashMap<SegKeyBuf, AnyValueEnum>>();
 
         Ok(SidebarPartStateInfo {
             position: get_from_cache::<SidebarPosition>(
@@ -194,7 +194,7 @@ impl LayoutService {
         )?
         .into_iter()
         .map(|(segkey, value)| (segkey, value))
-        .collect::<HashMap<SegKeyBuf, AnyValue>>();
+        .collect::<HashMap<SegKeyBuf, AnyValueEnum>>();
 
         Ok(ActivitybarPartStateInfo {
             last_active_container_id: get_from_cache::<String>(
@@ -256,7 +256,7 @@ impl LayoutService {
         )?
         .into_iter()
         .map(|(segkey, value)| (segkey, value))
-        .collect::<HashMap<SegKeyBuf, AnyValue>>();
+        .collect::<HashMap<SegKeyBuf, AnyValueEnum>>();
 
         Ok(PanelPartStateInfo {
             size: get_from_cache::<usize>(&mut panel_cache, PART_PANEL_SEGKEY.join("size"))
@@ -281,7 +281,7 @@ impl LayoutService {
         )?
         .into_iter()
         .map(|(segkey, value)| (segkey, value))
-        .collect::<HashMap<SegKeyBuf, AnyValue>>();
+        .collect::<HashMap<SegKeyBuf, AnyValueEnum>>();
 
         let grid = get_from_cache::<EditorGridStateEntity>(
             &mut editor_cache,
@@ -315,7 +315,7 @@ impl LayoutService {
 }
 
 fn get_from_cache<T: DeserializeOwned>(
-    cache: &mut HashMap<SegKeyBuf, AnyValue>,
+    cache: &mut HashMap<SegKeyBuf, AnyValueEnum>,
     key: SegKeyBuf,
 ) -> Option<T> {
     cache


### PR DESCRIPTION
Replace the use of `AnyValue` with `AnyValueEnum`. Right now, we are still using `serialize` method for all values, but in the future we will only use `serialize` on object values; for primitive values, we will simply use `any_value!` macro.