### PR TITLE
devops(SAPIC-330) Fix the tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["main"]
+    branches: [ "main" ]
   pull_request:
 
 concurrency:
@@ -140,7 +140,7 @@ jobs:
         uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
 
       - name: Run Tests - ${{ matrix.package }}
-        run: cargo test -p ${{ matrix.package }} --lib
+        run: cargo test -p ${{ matrix.package }}
 
   # Checks for Rust compiler warnings in each package individually.
   # This job is skipped for draft pull requests to allow developers to work

--- a/crates/moss-fs/src/real.rs
+++ b/crates/moss-fs/src/real.rs
@@ -80,6 +80,7 @@ impl FileSystem for RealFileSystem {
 
         let mut file = open_options.open(path).await?;
         file.write_all(content).await?;
+        file.flush().await?;
         Ok(())
     }
 

--- a/crates/moss-workbench/src/api/delete_workspace.rs
+++ b/crates/moss-workbench/src/api/delete_workspace.rs
@@ -52,10 +52,14 @@ impl<R: TauriRuntime> Workbench<R> {
             workspaces_lock.remove(&workspace_entry.id);
         }
 
-        if let Some(active_workspace) = self.active_workspace_mut().await.as_mut() {
-            if active_workspace.id == input.id {
-                self.deactivate_workspace().await;
-            }
+        if self
+            .active_workspace()
+            .await
+            .as_ref()
+            .map(|workspace| workspace.id)
+            == Some(input.id)
+        {
+            self.deactivate_workspace().await;
         }
 
         Ok(())


### PR DESCRIPTION
1. Make sure that CI pipeline will run integration tests.
2. Fix `Workbench::delete_workspace` deadlock issue
3. Fix a potential delay between file creation and content writing for `moss-fs::RealFileSystem` by flushing the content after writing.