### PR TITLE
fix(SAPIC-451): Fix crashing when exiting the workspace

### DIFF
--- a/crates/moss-app/src/services/log_service.rs
+++ b/crates/moss-app/src/services/log_service.rs
@@ -195,7 +195,7 @@ impl<R: AppRuntime> LogService<R> {
                 // Showing all logs (including span events) to the console
                 tracing_subscriber::fmt::layer()
                     .event_format(instrument_log_format)
-                    .with_span_events(FmtSpan::CLOSE)
+                    .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
                     .with_ansi(true)
                     .with_writer(io::stdout),
             )

--- a/libs/joinerror/src/ext.rs
+++ b/libs/joinerror/src/ext.rs
@@ -27,7 +27,7 @@ impl From<anyhow::Error> for Error {
 
 impl From<Error> for anyhow::Error {
     fn from(err: Error) -> Self {
-        anyhow!(err)
+        anyhow!(err.to_string())
     }
 }
 

--- a/view/desktop/src/components/SidebarWorkspaceContent.tsx
+++ b/view/desktop/src/components/SidebarWorkspaceContent.tsx
@@ -1,10 +1,11 @@
 import { useDescribeWorkspaceState } from "@/hooks/workspace/useDescribeWorkspaceState";
-import CollectionTreeView from "./CollectionTreeView";
 import {
   TREE_VIEW_GROUP_COLLECTIONS,
   TREE_VIEW_GROUP_ENVIRONMENTS,
   TREE_VIEW_GROUP_MOCK_SERVERS,
 } from "@repo/moss-workspace";
+
+import CollectionTreeView from "./CollectionTreeView";
 
 interface SidebarWorkspaceContentProps {
   workspaceName?: string | null;
@@ -13,7 +14,7 @@ interface SidebarWorkspaceContentProps {
 }
 
 export const SidebarWorkspaceContent = ({ workspaceName, groupId = "default" }: SidebarWorkspaceContentProps) => {
-  const { data: workspaceState, isLoading: isLoadingWorkspace, error: workspaceError } = useDescribeWorkspaceState({});
+  const { data: workspaceState, isLoading: isLoadingWorkspace, error: workspaceError } = useDescribeWorkspaceState();
 
   // Show loading state while workspace data is loading
   if (isLoadingWorkspace) {

--- a/view/desktop/src/hooks/collection/useStreamedCollectionEntries.ts
+++ b/view/desktop/src/hooks/collection/useStreamedCollectionEntries.ts
@@ -1,6 +1,7 @@
 import { EntryInfo } from "@repo/moss-collection";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
+import { useWorkspaceSidebarState } from "../workspace/useWorkspaceSidebarState";
 import { fetchCollectionEntries } from "./queries/fetchCollectionEntries";
 
 export const USE_STREAMED_COLLECTION_ENTRIES_QUERY_KEY = "streamCollectionEntries";
@@ -8,10 +9,13 @@ export const USE_STREAMED_COLLECTION_ENTRIES_QUERY_KEY = "streamCollectionEntrie
 export const useStreamedCollectionEntries = (collectionId: string) => {
   const queryClient = useQueryClient();
 
+  const { hasWorkspace } = useWorkspaceSidebarState();
+
   const query = useQuery<EntryInfo[], Error>({
     queryKey: [USE_STREAMED_COLLECTION_ENTRIES_QUERY_KEY, collectionId],
     queryFn: () => fetchCollectionEntries(collectionId),
     placeholderData: [],
+    enabled: hasWorkspace,
   });
 
   const clearEntriesCacheAndRefetch = () => {

--- a/view/desktop/src/hooks/collection/useStreamedCollections.ts
+++ b/view/desktop/src/hooks/collection/useStreamedCollections.ts
@@ -24,9 +24,9 @@ const startStreamingCollections = async (): Promise<StreamCollectionsEvent[]> =>
 };
 
 export const useStreamedCollections = () => {
-  const { hasWorkspace } = useWorkspaceSidebarState();
-
   const queryClient = useQueryClient();
+
+  const { hasWorkspace } = useWorkspaceSidebarState();
 
   const query = useQuery<StreamCollectionsEvent[], Error>({
     queryKey: [USE_STREAMED_COLLECTIONS_QUERY_KEY],

--- a/view/desktop/src/hooks/workbench/useCloseWorkspace.ts
+++ b/view/desktop/src/hooks/workbench/useCloseWorkspace.ts
@@ -3,8 +3,6 @@ import { CloseWorkspaceInput, CloseWorkspaceOutput } from "@repo/moss-app";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { USE_DESCRIBE_APP_STATE_QUERY_KEY } from "../appState/useDescribeAppState";
-import { USE_STREAMED_COLLECTION_ENTRIES_QUERY_KEY, USE_STREAMED_COLLECTIONS_QUERY_KEY } from "../collection";
-import { USE_DESCRIBE_WORKSPACE_STATE_QUERY_KEY } from "../workspace/useDescribeWorkspaceState";
 import { USE_LIST_WORKSPACES_QUERY_KEY } from "./useListWorkspaces";
 
 export const USE_CLOSE_WORKSPACE_QUERY_KEY = "closeWorkspace";

--- a/view/desktop/src/hooks/workbench/useCloseWorkspace.ts
+++ b/view/desktop/src/hooks/workbench/useCloseWorkspace.ts
@@ -1,8 +1,11 @@
 import { invokeTauriIpc } from "@/lib/backend/tauri";
-import { CloseWorkspaceInput, CloseWorkspaceOutput } from "@repo/moss-app";
+import { CloseWorkspaceInput, CloseWorkspaceOutput, ListWorkspacesOutput } from "@repo/moss-app";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
+import { USE_STREAMED_COLLECTION_ENTRIES_QUERY_KEY } from "..";
 import { USE_DESCRIBE_APP_STATE_QUERY_KEY } from "../appState/useDescribeAppState";
+import { USE_STREAMED_COLLECTIONS_QUERY_KEY } from "../collection";
+import { USE_DESCRIBE_WORKSPACE_STATE_QUERY_KEY } from "../workspace";
 import { USE_LIST_WORKSPACES_QUERY_KEY } from "./useListWorkspaces";
 
 export const USE_CLOSE_WORKSPACE_QUERY_KEY = "closeWorkspace";
@@ -29,7 +32,15 @@ export const useCloseWorkspace = () => {
     onSuccess: () => {
       // Invalidate other related queries
       queryClient.invalidateQueries({ queryKey: [USE_LIST_WORKSPACES_QUERY_KEY] });
+      queryClient.setQueryData([USE_LIST_WORKSPACES_QUERY_KEY], (old: ListWorkspacesOutput) => {
+        return old.map((workspace) => ({ ...workspace, active: false }));
+      });
       queryClient.invalidateQueries({ queryKey: [USE_DESCRIBE_APP_STATE_QUERY_KEY] });
+
+      // Remove ALL cached workspace state queries since no workspace is active
+      queryClient.removeQueries({ queryKey: [USE_DESCRIBE_WORKSPACE_STATE_QUERY_KEY] });
+      queryClient.removeQueries({ queryKey: [USE_STREAMED_COLLECTIONS_QUERY_KEY] });
+      queryClient.removeQueries({ queryKey: [USE_STREAMED_COLLECTION_ENTRIES_QUERY_KEY] });
     },
   });
 };

--- a/view/desktop/src/hooks/workbench/useCloseWorkspace.ts
+++ b/view/desktop/src/hooks/workbench/useCloseWorkspace.ts
@@ -29,20 +29,9 @@ export const useCloseWorkspace = () => {
     mutationKey: [USE_CLOSE_WORKSPACE_QUERY_KEY],
     mutationFn: closeWorkspaceFn,
     onSuccess: () => {
-      // Remove ALL cached workspace state queries since no workspace is active
-      queryClient.removeQueries({
-        queryKey: [USE_DESCRIBE_WORKSPACE_STATE_QUERY_KEY],
-        exact: false,
-      });
-      queryClient.removeQueries({ queryKey: [USE_STREAMED_COLLECTIONS_QUERY_KEY], exact: true });
-      queryClient.removeQueries({ queryKey: [USE_STREAMED_COLLECTION_ENTRIES_QUERY_KEY], exact: true });
-
       // Invalidate other related queries
       queryClient.invalidateQueries({ queryKey: [USE_LIST_WORKSPACES_QUERY_KEY] });
       queryClient.invalidateQueries({ queryKey: [USE_DESCRIBE_APP_STATE_QUERY_KEY] });
-
-      queryClient.invalidateQueries({ queryKey: [USE_STREAMED_COLLECTIONS_QUERY_KEY], exact: true });
-      queryClient.invalidateQueries({ queryKey: [USE_STREAMED_COLLECTION_ENTRIES_QUERY_KEY], exact: true });
     },
   });
 };

--- a/view/desktop/src/hooks/workspace/useDescribeWorkspaceState.ts
+++ b/view/desktop/src/hooks/workspace/useDescribeWorkspaceState.ts
@@ -1,6 +1,7 @@
 import { invokeTauriIpc } from "@/lib/backend/tauri";
 import { DescribeStateOutput } from "@repo/moss-workspace";
 import { useQuery } from "@tanstack/react-query";
+
 import { useActiveWorkspace } from "./useActiveWorkspace";
 
 export const USE_DESCRIBE_WORKSPACE_STATE_QUERY_KEY = "describeWorkspaceState";
@@ -19,8 +20,7 @@ interface UseDescribeWorkspaceStateOptions {
   enabled?: boolean;
 }
 
-export const useDescribeWorkspaceState = (options: UseDescribeWorkspaceStateOptions = {}) => {
-  const { enabled = true } = options;
+export const useDescribeWorkspaceState = ({ enabled = true }: UseDescribeWorkspaceStateOptions = {}) => {
   const workspace = useActiveWorkspace();
   const workspaceId = workspace?.id || null;
 

--- a/view/desktop/src/hooks/workspace/useWorkspaceSidebarState.ts
+++ b/view/desktop/src/hooks/workspace/useWorkspaceSidebarState.ts
@@ -1,8 +1,10 @@
 import { useEffect, useRef } from "react";
-import { useAppResizableLayoutStore } from "@/store/appResizableLayout";
-import { useDescribeWorkspaceState } from "./useDescribeWorkspaceState";
+
 import { useUpdateSidebarPartState } from "@/hooks/appState/useUpdateSidebarPartState";
+import { useAppResizableLayoutStore } from "@/store/appResizableLayout";
+
 import { useActiveWorkspace } from "./useActiveWorkspace";
+import { useDescribeWorkspaceState } from "./useDescribeWorkspaceState";
 
 export const useWorkspaceSidebarState = () => {
   const workspace = useActiveWorkspace();
@@ -16,13 +18,7 @@ export const useWorkspaceSidebarState = () => {
   const isTransitioning = useRef(false);
 
   // Fetch workspace state only when we have an active workspace
-  const {
-    data: workspaceState,
-    isFetched,
-    isSuccess,
-  } = useDescribeWorkspaceState({
-    enabled: !!workspaceId,
-  });
+  const { data: workspaceState, isFetched, isSuccess } = useDescribeWorkspaceState();
 
   // Reset state tracking when workspace changes
   useEffect(() => {

--- a/view/desktop/src/layouts/AppLayout.tsx
+++ b/view/desktop/src/layouts/AppLayout.tsx
@@ -32,13 +32,7 @@ export const AppLayout = ({ children }: AppLayoutProps) => {
   const { bottomPane, sideBar, sideBarPosition } = useAppResizableLayoutStore();
 
   // Fetch workspace state to know when initialization is complete
-  const {
-    data: workspaceState,
-    isFetched,
-    isSuccess,
-  } = useDescribeWorkspaceState({
-    enabled: !!workspace,
-  });
+  const { data: workspaceState, isFetched, isSuccess } = useDescribeWorkspaceState();
 
   // Reset update permission when workspace changes
   useEffect(() => {

--- a/view/desktop/src/parts/TabbedPane/TabbedPane.tsx
+++ b/view/desktop/src/parts/TabbedPane/TabbedPane.tsx
@@ -20,7 +20,6 @@ import {
   WelcomePage,
   WorkspaceSettings,
 } from "@/pages";
-
 import { useTabbedPaneStore } from "@/store/tabbedPane";
 import { cn } from "@/utils";
 import { EntryKind } from "@repo/moss-collection";


### PR DESCRIPTION
The issue is a combination of both incorrect frontend logic and a subtle bug in the backend's joinerror library:

1. The frontend mistakenly invalidated `describe_workspace_state` and `stream_collection_entries` queries after closing a workspace. However, both commands will fail if there's no active workspace.
2. The conversion between `joinerror::Result` and `TauriResult` has a subtle error: it tries to convert `joinerror::Error` to `anyhow::Error` first, but the conversion function inadvertently calls itself, leading to infinite recursion.
3. The commands instrumentation only generates logs when we finish with the command, leading to initial false direction on which commands are the culprit.

This PR fixes both the frontend `useCloseWorkspace` hook and the backend `joinerror` library, and added opening instrumentation for tauri commands.