### PR TITLE
fix(SAPIC-428): Frontend Page re rendering when switching the sidebar

### DIFF
--- a/view/desktop/index.html
+++ b/view/desktop/index.html
@@ -4,6 +4,9 @@
 <head>
   <meta charset="UTF-8" name="viewport" content="width=device-width, initial-scale=1.0" />
 
+  <!-- react-scan -->
+  <!-- <script crossOrigin="anonymous" src="//unpkg.com/react-scan/dist/auto.global.js"></script> -->
+
   <!-- Favicon links -->
   <link rel="icon" type="image/x-icon" href="/favicon.ico" />
   <link rel="icon" type="image/png" sizes="32x32" href="/32x32.png" />

--- a/view/desktop/src/components/CollectionTree/TreeNode/TreeNodeButton.tsx
+++ b/view/desktop/src/components/CollectionTree/TreeNode/TreeNodeButton.tsx
@@ -63,7 +63,7 @@ const TreeNodeButton = forwardRef<HTMLDivElement, TreeNodeButtonProps>(
       if (node.kind === "Dir") {
         addOrFocusPanel({
           id: node.id,
-          title: `${node.name} Settings`,
+          title: node.name,
           params: {
             collectionId: id,
             node: {
@@ -88,7 +88,7 @@ const TreeNodeButton = forwardRef<HTMLDivElement, TreeNodeButtonProps>(
       } else {
         addOrFocusPanel({
           id: node.id,
-          title: `${node.name} Settings`,
+          title: node.name,
           params: {
             collectionId: id,
             node,

--- a/view/desktop/src/components/CollectionTree/TreeNode/TreeNodeButton.tsx
+++ b/view/desktop/src/components/CollectionTree/TreeNode/TreeNodeButton.tsx
@@ -94,7 +94,7 @@ const TreeNodeButton = forwardRef<HTMLDivElement, TreeNodeButtonProps>(
             collectionId: id,
             node,
           },
-          component: "Default",
+          component: node.class === "Request" ? "Request" : "Default",
         });
       }
     };

--- a/view/desktop/src/components/CollectionTree/TreeNode/TreeNodeButton.tsx
+++ b/view/desktop/src/components/CollectionTree/TreeNode/TreeNodeButton.tsx
@@ -66,7 +66,6 @@ const TreeNodeButton = forwardRef<HTMLDivElement, TreeNodeButtonProps>(
           title: `${node.name} Settings`,
           params: {
             collectionId: id,
-            iconType: node.kind,
             node: {
               ...node,
               expanded: true,

--- a/view/desktop/src/components/CollectionTree/TreeNode/TreeNodeButton.tsx
+++ b/view/desktop/src/components/CollectionTree/TreeNode/TreeNodeButton.tsx
@@ -86,6 +86,16 @@ const TreeNodeButton = forwardRef<HTMLDivElement, TreeNodeButtonProps>(
             },
           });
         }
+      } else {
+        addOrFocusPanel({
+          id: node.id,
+          title: `${node.name} Settings`,
+          params: {
+            collectionId: id,
+            node,
+          },
+          component: "Default",
+        });
       }
     };
 

--- a/view/desktop/src/components/SidebarWorkspaceContent.tsx
+++ b/view/desktop/src/components/SidebarWorkspaceContent.tsx
@@ -1,10 +1,11 @@
 import { useDescribeWorkspaceState } from "@/hooks/workspace/useDescribeWorkspaceState";
-import CollectionTreeView from "./CollectionTreeView";
 import {
   TREE_VIEW_GROUP_COLLECTIONS,
   TREE_VIEW_GROUP_ENVIRONMENTS,
   TREE_VIEW_GROUP_MOCK_SERVERS,
 } from "@repo/moss-workspace";
+
+import CollectionTreeView from "./CollectionTreeView";
 
 interface SidebarWorkspaceContentProps {
   workspaceName?: string | null;
@@ -13,7 +14,7 @@ interface SidebarWorkspaceContentProps {
 }
 
 export const SidebarWorkspaceContent = ({ workspaceName, groupId = "default" }: SidebarWorkspaceContentProps) => {
-  const { data: workspaceState, isLoading: isLoadingWorkspace, error: workspaceError } = useDescribeWorkspaceState({});
+  const { data: workspaceState, isLoading: isLoadingWorkspace, error: workspaceError } = useDescribeWorkspaceState();
 
   // Show loading state while workspace data is loading
   if (isLoadingWorkspace) {

--- a/view/desktop/src/hooks/appState/useUpdateActivitybarPartState.ts
+++ b/view/desktop/src/hooks/appState/useUpdateActivitybarPartState.ts
@@ -1,9 +1,10 @@
 import { DEBOUNCE_TIME } from "@/constants/tanstackConfig";
 import { invokeTauriIpc } from "@/lib/backend/tauri";
-import { ActivitybarPartStateInfo } from "@repo/moss-workspace";
+import { ActivitybarPartStateInfo, DescribeStateOutput } from "@repo/moss-workspace";
 import { asyncDebounce } from "@tanstack/react-pacer/async-debouncer";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { USE_DESCRIBE_WORKSPACE_STATE_QUERY_KEY } from "@/hooks/workspace/useDescribeWorkspaceState";
+
+import { USE_DESCRIBE_WORKSPACE_STATE_QUERY_KEY } from "../workspace/useDescribeWorkspaceState";
 
 export const USE_UPDATE_ACTIVITYBAR_PART_STATE_MUTATION_KEY = "updateActivitybarPartState";
 
@@ -24,9 +25,13 @@ export const useUpdateActivitybarPartState = () => {
     mutationFn: async (activitybar: ActivitybarPartStateInfo): Promise<void> => {
       await debouncedSetActivitybarPartState(activitybar);
     },
-    onSuccess: () => {
-      // Invalidate workspace state to refetch latest data
-      queryClient.invalidateQueries({ queryKey: [USE_DESCRIBE_WORKSPACE_STATE_QUERY_KEY] });
+    onSuccess: (_, variables) => {
+      queryClient.setQueryData<DescribeStateOutput>([USE_DESCRIBE_WORKSPACE_STATE_QUERY_KEY], (old) => {
+        return {
+          ...old,
+          activitybar: variables,
+        };
+      });
     },
   });
 };

--- a/view/desktop/src/hooks/appState/utils/index.ts
+++ b/view/desktop/src/hooks/appState/utils/index.ts
@@ -56,6 +56,7 @@ export const mapSerializedDockviewToEditorPartState = (dockview: SerializedDockv
     grid: { root, height, width, orientation },
   } = dockview;
 
+  //FIXME: type error here
   return {
     panels,
     activeGroup,

--- a/view/desktop/src/hooks/workspace/useWorkspaceSidebarState.ts
+++ b/view/desktop/src/hooks/workspace/useWorkspaceSidebarState.ts
@@ -1,8 +1,10 @@
 import { useEffect, useRef } from "react";
-import { useAppResizableLayoutStore } from "@/store/appResizableLayout";
-import { useDescribeWorkspaceState } from "./useDescribeWorkspaceState";
+
 import { useUpdateSidebarPartState } from "@/hooks/appState/useUpdateSidebarPartState";
+import { useAppResizableLayoutStore } from "@/store/appResizableLayout";
+
 import { useActiveWorkspace } from "./useActiveWorkspace";
+import { useDescribeWorkspaceState } from "./useDescribeWorkspaceState";
 
 export const useWorkspaceSidebarState = () => {
   const workspace = useActiveWorkspace();
@@ -16,13 +18,7 @@ export const useWorkspaceSidebarState = () => {
   const isTransitioning = useRef(false);
 
   // Fetch workspace state only when we have an active workspace
-  const {
-    data: workspaceState,
-    isFetched,
-    isSuccess,
-  } = useDescribeWorkspaceState({
-    enabled: !!workspaceId,
-  });
+  const { data: workspaceState, isFetched, isSuccess } = useDescribeWorkspaceState();
 
   // Reset state tracking when workspace changes
   useEffect(() => {

--- a/view/desktop/src/layouts/AppLayout.tsx
+++ b/view/desktop/src/layouts/AppLayout.tsx
@@ -32,13 +32,7 @@ export const AppLayout = ({ children }: AppLayoutProps) => {
   const { bottomPane, sideBar, sideBarPosition } = useAppResizableLayoutStore();
 
   // Fetch workspace state to know when initialization is complete
-  const {
-    data: workspaceState,
-    isFetched,
-    isSuccess,
-  } = useDescribeWorkspaceState({
-    enabled: !!workspace,
-  });
+  const { data: workspaceState, isFetched, isSuccess } = useDescribeWorkspaceState();
 
   // Reset update permission when workspace changes
   useEffect(() => {


### PR DESCRIPTION
- fixed re-rendering when switching the sidebar
- fixed entry doesn't open when clicking on tree node
- commented out react-scan to simplify it's usage in the future