### PR TITLE
refactor(SAPIC-443): Rethinking the concept of logs and fully integrating them into the application

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,7 @@ jobs:
           - moss_file
           - moss_bindingutils
           - moss_hcl
+          - moss_logging
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -259,6 +260,7 @@ jobs:
           - desktop
           - moss_bindingutils
           - moss_hcl
+          - moss_logging
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0

--- a/.idea/sapic.iml
+++ b/.idea/sapic.iml
@@ -42,14 +42,15 @@
       <sourceFolder url="file://$MODULE_DIR$/libs/joinerror/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/crates/moss-jsdoc-macro/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/crates/moss-jsdoc/src" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/crates/moss-git-hosting-provider/tests" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/misc/wasm_plugins/rust_demo/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/libs/atomic-fs/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/libs/atomic-fs/tests" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/crates/moss-contentmodel/src" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/crates/moss-edit/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/moss-git-hosting-provider/tests" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/crates/moss-git-hosting-provider/tests" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/crates/moss-contentmodel/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/moss-contentmodel/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/moss-logging/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/moss-edit/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/crates/moss-edit/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/crates/moss-workspacelib/src" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/.venv1" />

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,7 +662,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
- "regex-automata",
+ "regex-automata 0.4.9",
  "serde",
 ]
 
@@ -3558,6 +3558,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5552,8 +5561,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -5564,8 +5582,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -7328,11 +7352,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "chrono",
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "serde",
  "serde_json",
  "sharded-slab",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3702,6 +3702,7 @@ dependencies = [
  "moss_fs",
  "moss_git_hosting_provider",
  "moss_keyring",
+ "moss_logging",
  "moss_storage",
  "moss_testutils",
  "moss_text",
@@ -3945,6 +3946,17 @@ version = "0.1.0"
 dependencies = [
  "keyring",
  "whoami",
+]
+
+[[package]]
+name = "moss_logging"
+version = "0.1.0"
+dependencies = [
+ "derive_more 2.0.1",
+ "nanoid",
+ "serde",
+ "tracing",
+ "ts-rs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,8 @@ members = [
     "crates/moss-hcl", 
     "crates/moss-bindingutils", 
     "crates/moss-wasm",
-    "crates/moss-edit", 
+    "crates/moss-edit",
+    "crates/moss-logging",
     #
     # Apps
     #
@@ -39,7 +40,7 @@ members = [
     #
     # Tools
     #
-    "tools/xtask", 
+    "tools/xtask",
 ]
 
 [workspace.dependencies]
@@ -72,6 +73,7 @@ moss_hcl = { path = "crates/moss-hcl" }
 moss_bindingutils = { path = "crates/moss-bindingutils" }
 moss_wasm = { path = "crates/moss-wasm" }
 moss_edit = { path = "crates/moss-edit" }
+moss_logging = { path = "crates/moss-logging" }
 atomic_fs = { path = "libs/atomic-fs" }
 
 #

--- a/crates/moss-app/Cargo.toml
+++ b/crates/moss-app/Cargo.toml
@@ -30,7 +30,7 @@ serde = { workspace = true, features = ["derive", "rc"] }
 ts-rs.workspace = true
 chrono.workspace = true
 tracing.workspace = true
-tracing-subscriber = { workspace = true, features = ["fmt", "json", "chrono", "ansi"] }
+tracing-subscriber = { workspace = true, features = ["fmt", "json", "chrono", "ansi", "env-filter"] }
 tracing-appender.workspace = true
 derive_more = { workspace = true, features = ["deref", "deref_mut", "from"] }
 validator.workspace = true

--- a/crates/moss-app/Cargo.toml
+++ b/crates/moss-app/Cargo.toml
@@ -16,6 +16,7 @@ moss_activity_indicator.workspace = true
 moss_environment.workspace = true
 moss_git_hosting_provider.workspace = true
 moss_keyring.workspace = true
+moss_logging.workspace = true
 
 joinerror.workspace = true
 futures.workspace = true

--- a/crates/moss-app/src/api/batch_delete_log.rs
+++ b/crates/moss-app/src/api/batch_delete_log.rs
@@ -1,5 +1,4 @@
 use moss_applib::AppRuntime;
-use moss_common::api::OperationResult;
 
 use crate::{
     app::App,
@@ -11,12 +10,11 @@ impl<R: AppRuntime> App<R> {
         &self,
         ctx: &R::AsyncContext,
         input: &BatchDeleteLogInput,
-    ) -> OperationResult<BatchDeleteLogOutput> {
-        match self.log_service.delete_logs(ctx, input.ids.iter()).await {
-            Ok(output) => Ok(BatchDeleteLogOutput {
-                deleted_entries: output,
-            }),
-            Err(e) => Err(e.into()),
-        }
+    ) -> joinerror::Result<BatchDeleteLogOutput> {
+        let output = self.log_service.delete_logs(ctx, input.ids.iter()).await?;
+
+        Ok(BatchDeleteLogOutput {
+            deleted_entries: output,
+        })
     }
 }

--- a/crates/moss-app/src/api/list_logs.rs
+++ b/crates/moss-app/src/api/list_logs.rs
@@ -1,6 +1,5 @@
 use chrono::NaiveDate;
 use moss_applib::AppRuntime;
-use moss_common::api::OperationResult;
 
 use crate::{
     app::App,
@@ -13,7 +12,7 @@ impl<R: AppRuntime> App<R> {
         &self,
         _ctx: &R::AsyncContext,
         input: &ListLogsInput,
-    ) -> OperationResult<ListLogsOutput> {
+    ) -> joinerror::Result<ListLogsOutput> {
         let filter = LogFilter {
             // Skip invalid dates
             dates: input
@@ -25,9 +24,7 @@ impl<R: AppRuntime> App<R> {
             resource: input.resource.clone(),
         };
 
-        match self.log_service.list_logs_with_filter(&filter).await {
-            Ok(contents) => Ok(ListLogsOutput { contents }),
-            Err(e) => Err(e.into()),
-        }
+        let contents = self.log_service.list_logs_with_filter(&filter).await?;
+        Ok(ListLogsOutput { contents })
     }
 }

--- a/crates/moss-app/src/models/operations.rs
+++ b/crates/moss-app/src/models/operations.rs
@@ -1,17 +1,17 @@
 use std::{path::Path, sync::Arc};
 
+use super::types::{ColorThemeInfo, Defaults, LocaleInfo, Preferences};
+use crate::models::{
+    primitives::{LogLevel, ThemeId, WorkspaceId},
+    types::{LogDate, LogEntryInfo, LogItemSourceInfo, WorkspaceInfo},
+};
 use derive_more::Deref;
+use moss_logging::models::primitives::LogEntryId;
 use moss_workspace::models::types::WorkspaceMode;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use ts_rs::TS;
 use validator::Validate;
-
-use super::types::{ColorThemeInfo, Defaults, LocaleInfo, Preferences};
-use crate::models::{
-    primitives::{LogEntryId, LogLevel, ThemeId, WorkspaceId},
-    types::{LogDate, LogEntryInfo, LogItemSourceInfo, WorkspaceInfo},
-};
 // ########################################################
 // ###                   Cancellation                   ###
 // ########################################################

--- a/crates/moss-app/src/models/primitives.rs
+++ b/crates/moss-app/src/models/primitives.rs
@@ -38,33 +38,6 @@ impl Display for WorkspaceId {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Hash, Eq, Deref, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct LogEntryId(Arc<String>);
-impl LogEntryId {
-    pub fn new() -> Self {
-        Self(Arc::new(nanoid!(10)))
-    }
-}
-
-impl From<String> for LogEntryId {
-    fn from(s: String) -> Self {
-        Self(Arc::new(s))
-    }
-}
-
-impl AsRef<str> for LogEntryId {
-    fn as_ref(&self) -> &str {
-        self.0.as_ref()
-    }
-}
-
-impl Display for LogEntryId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
 // ########################################################
 // ###                      Theme                       ###
 // ########################################################

--- a/crates/moss-app/src/models/types.rs
+++ b/crates/moss-app/src/models/types.rs
@@ -1,3 +1,4 @@
+use moss_logging::models::primitives::LogEntryId;
 use serde::{Deserialize, Serialize};
 use std::{
     path::{Path, PathBuf},
@@ -5,7 +6,7 @@ use std::{
 };
 use ts_rs::TS;
 
-use crate::models::primitives::{LocaleId, LogEntryId, LogLevel, ThemeId, ThemeMode, WorkspaceId};
+use crate::models::primitives::{LocaleId, LogLevel, ThemeId, ThemeMode, WorkspaceId};
 
 // ########################################################
 // ###                      Locale                      ###

--- a/crates/moss-app/src/services/log_service.rs
+++ b/crates/moss-app/src/services/log_service.rs
@@ -249,10 +249,7 @@ impl<R: AppRuntime> LogService<R> {
         let mut result = Vec::new();
         for entry_id in input {
             // Try deleting from applog queue
-            let mut applog_queue_lock = self
-                .applog_queue
-                .lock()
-                .map_err(|_| joinerror::Error::new::<()>("mutex poisoned"))?;
+            let mut applog_queue_lock = self.applog_queue.lock()?;
             let idx = applog_queue_lock.iter().position(|x| &x.id == entry_id);
             if let Some(idx) = idx {
                 applog_queue_lock.remove(idx);
@@ -265,10 +262,7 @@ impl<R: AppRuntime> LogService<R> {
             drop(applog_queue_lock);
 
             // Try deleting from sessionlog queue
-            let mut sessionlog_queue_lock = self
-                .sessionlog_queue
-                .lock()
-                .map_err(|_| joinerror::Error::new::<()>("mutex poisoned"))?;
+            let mut sessionlog_queue_lock = self.sessionlog_queue.lock()?;
             let idx = sessionlog_queue_lock.iter().position(|x| &x.id == entry_id);
             if let Some(idx) = idx {
                 sessionlog_queue_lock.remove(idx);
@@ -472,9 +466,7 @@ impl<R: AppRuntime> LogService<R> {
         // The logs in the queue must be more recent than the logs in files
         // So we append them to the end
         result.extend({
-            let lock = queue
-                .lock()
-                .map_err(|_| joinerror::Error::new::<()>("mutex poisoned"))?;
+            let lock = queue.lock()?;
 
             lock.clone()
                 .into_iter()

--- a/crates/moss-app/src/services/log_service.rs
+++ b/crates/moss-app/src/services/log_service.rs
@@ -526,7 +526,7 @@ mod tests {
     use crate::constants::LOGGING_SERVICE_CHANNEL;
     use moss_applib::mock::MockAppRuntime;
     use moss_fs::RealFileSystem;
-    use moss_logging::{LogPayload, LogScope, debug};
+    use moss_logging::{LogEvent, LogScope, debug};
     use moss_testutils::random_name::random_string;
     use std::{fs::create_dir_all, sync::atomic::AtomicUsize, time::Duration};
     use tauri::{Listener, Manager};
@@ -567,7 +567,7 @@ mod tests {
 
         debug(
             LogScope::App,
-            LogPayload {
+            LogEvent {
                 resource: None,
                 message: "".to_string(),
             },

--- a/crates/moss-app/src/services/storage_service.rs
+++ b/crates/moss-app/src/services/storage_service.rs
@@ -1,9 +1,6 @@
-use crate::{
-    models::primitives::{LogEntryId, WorkspaceId},
-    storage::segments::{SEGKEY_LAST_ACTIVE_WORKSPACE, segkey_last_opened_at},
-};
 use moss_applib::{AppRuntime, ServiceMarker};
 use moss_db::{DatabaseResult, Transaction, primitives::AnyValue};
+use moss_logging::models::primitives::LogEntryId;
 use moss_storage::{
     GlobalStorage,
     global_storage::GlobalStorageImpl,
@@ -17,6 +14,11 @@ use std::{
     collections::HashMap,
     path::{Path, PathBuf},
     sync::Arc,
+};
+
+use crate::{
+    models::primitives::WorkspaceId,
+    storage::segments::{SEGKEY_LAST_ACTIVE_WORKSPACE, segkey_last_opened_at},
 };
 
 pub struct StorageService<R: AppRuntime> {

--- a/crates/moss-app/tests/app__batch_delete_logs.rs
+++ b/crates/moss-app/tests/app__batch_delete_logs.rs
@@ -1,7 +1,7 @@
 pub mod shared;
 
 use moss_app::models::operations::{BatchDeleteLogInput, ListLogsInput};
-use moss_logging::{LogPayload, LogScope, warn};
+use moss_logging::{LogEvent, LogScope, warn};
 
 use crate::shared::set_up_test_app;
 
@@ -20,7 +20,7 @@ async fn test_delete_logs_from_queue() {
     // So we should delete from the queue
     warn(
         LogScope::App,
-        LogPayload {
+        LogEvent {
             resource: None,
             message: "".to_string(),
         },
@@ -74,7 +74,7 @@ async fn test_delete_logs_from_file() {
     for _ in 0..15 {
         warn(
             LogScope::App,
-            LogPayload {
+            LogEvent {
                 resource: None,
                 message: "".to_string(),
             },
@@ -128,7 +128,7 @@ async fn test_delete_all_logs() {
     for _ in 0..15 {
         warn(
             LogScope::App,
-            LogPayload {
+            LogEvent {
                 resource: None,
                 message: "".to_string(),
             },

--- a/crates/moss-app/tests/app__batch_delete_logs.rs
+++ b/crates/moss-app/tests/app__batch_delete_logs.rs
@@ -1,185 +1,177 @@
-// FIXME: These tests are temporarily commented out because we need to rethink our approach to log management.
+pub mod shared;
 
-// pub mod shared;
+use moss_app::models::operations::{BatchDeleteLogInput, ListLogsInput};
+use moss_logging::{LogPayload, LogScope, warn};
 
-// use moss_app::{
-//     models::operations::{BatchDeleteLogInput, ListLogsInput},
-//     services::log_service::{LogPayload, LogScope, LogService},
-// };
-// use moss_applib::mock::MockAppRuntime;
+use crate::shared::set_up_test_app;
 
-// use crate::shared::set_up_test_app;
+/// These tests can work one at a time, but cannot be executed together using `cargo test`.
+/// This is because LoggingService will set a global default subscriber.
+/// However, it can only be set once per a program,
+/// While the `cargo test` model will run every test as part of the same program.
+/// Thus, they are marked as ignored.
 
-// /// These tests can work one at a time, but cannot be executed together using `cargo test`.
-// /// This is because LoggingService will set a global default subscriber.
-// /// However, it can only be set once per a program,
-// /// While the `cargo test` model will run every test as part of the same program.
-// /// Thus, they are marked as ignored.
+#[ignore]
+#[tokio::test]
+async fn test_delete_logs_from_queue() {
+    let (app, ctx, cleanup) = set_up_test_app().await;
 
-// #[ignore]
-// #[tokio::test]
-// async fn test_delete_logs_from_queue() {
-//     let (app, ctx, cleanup) = set_up_test_app().await;
-//     // let log_service = services.get::<LogService<MockAppRuntime>>();
+    // We only have one log, less than the dump threshold
+    // So we should delete from the queue
+    warn(
+        LogScope::App,
+        LogPayload {
+            resource: None,
+            message: "".to_string(),
+        },
+    );
 
-//     // We only have one log, less than the dump threshold
-//     // So we should delete from the queue
-//     log_service.warn(
-//         LogScope::App,
-//         LogPayload {
-//             resource: None,
-//             message: "".to_string(),
-//         },
-//     );
+    let logs = app
+        .list_logs(
+            &ctx,
+            &ListLogsInput {
+                dates: vec![],
+                levels: vec![],
+                resource: None,
+            },
+        )
+        .await
+        .unwrap()
+        .contents;
 
-//     let logs = app
-//         .list_logs(
-//             &ctx,
-//             &ListLogsInput {
-//                 dates: vec![],
-//                 levels: vec![],
-//                 resource: None,
-//             },
-//         )
-//         .await
-//         .unwrap()
-//         .contents;
+    let input = BatchDeleteLogInput {
+        ids: logs.into_iter().map(|log| log.id).collect(),
+    };
 
-//     let input = BatchDeleteLogInput {
-//         ids: logs.into_iter().map(|log| log.id).collect(),
-//     };
+    let output = app.batch_delete_log(&ctx, &input).await.unwrap();
+    let deleted_entries = output.deleted_entries;
+    assert_eq!(deleted_entries.len(), 1);
+    assert_eq!(deleted_entries[0].id, input.ids[0]);
+    assert!(deleted_entries[0].file_path.is_none());
 
-//     let output = app.batch_delete_log(&ctx, &input).await.unwrap();
-//     let deleted_entries = output.deleted_entries;
-//     assert_eq!(deleted_entries.len(), 1);
-//     assert_eq!(deleted_entries[0].id, input.ids[0]);
-//     assert!(deleted_entries[0].file_path.is_none());
+    let new_logs = app
+        .list_logs(
+            &ctx,
+            &ListLogsInput {
+                dates: vec![],
+                levels: vec![],
+                resource: None,
+            },
+        )
+        .await
+        .unwrap()
+        .contents;
+    assert!(new_logs.is_empty());
+    cleanup().await;
+}
 
-//     let new_logs = app
-//         .list_logs(
-//             &ctx,
-//             &ListLogsInput {
-//                 dates: vec![],
-//                 levels: vec![],
-//                 resource: None,
-//             },
-//         )
-//         .await
-//         .unwrap()
-//         .contents;
-//     assert!(new_logs.is_empty());
-//     cleanup().await;
-// }
+#[ignore]
+#[tokio::test]
+async fn test_delete_logs_from_file() {
+    let (app, ctx, cleanup) = set_up_test_app().await;
 
-// #[ignore]
-// #[tokio::test]
-// async fn test_delete_logs_from_file() {
-//     let (app, ctx, services, cleanup, _abs_path) = set_up_test_app().await;
-//     let log_service = services.get::<LogService<MockAppRuntime>>();
+    // By default, the dump threshold is 10, which means that the first log
+    for _ in 0..15 {
+        warn(
+            LogScope::App,
+            LogPayload {
+                resource: None,
+                message: "".to_string(),
+            },
+        );
+    }
 
-//     // By default, the dump threshold is 10, which means that the first log
-//     for _ in 0..15 {
-//         log_service.warn(
-//             LogScope::App,
-//             LogPayload {
-//                 resource: None,
-//                 message: "".to_string(),
-//             },
-//         );
-//     }
+    let logs = app
+        .list_logs(
+            &ctx,
+            &ListLogsInput {
+                dates: vec![],
+                levels: vec![],
+                resource: None,
+            },
+        )
+        .await
+        .unwrap()
+        .contents;
 
-//     let logs = app
-//         .list_logs(
-//             &ctx,
-//             &ListLogsInput {
-//                 dates: vec![],
-//                 levels: vec![],
-//                 resource: None,
-//             },
-//         )
-//         .await
-//         .unwrap()
-//         .contents;
+    let input = BatchDeleteLogInput {
+        ids: vec![logs[0].id.clone()],
+    };
 
-//     let input = BatchDeleteLogInput {
-//         ids: vec![logs[0].id.clone()],
-//     };
+    let output = app.batch_delete_log(&ctx, &input).await.unwrap();
+    let deleted_entries = output.deleted_entries;
+    assert_eq!(deleted_entries.len(), 1);
+    assert_eq!(deleted_entries[0].id, input.ids[0]);
+    // It should be deleted from a file
+    assert!(deleted_entries[0].file_path.is_some());
 
-//     let output = app.batch_delete_log(&ctx, &input).await.unwrap();
-//     let deleted_entries = output.deleted_entries;
-//     assert_eq!(deleted_entries.len(), 1);
-//     assert_eq!(deleted_entries[0].id, input.ids[0]);
-//     // It should be deleted from a file
-//     assert!(deleted_entries[0].file_path.is_some());
+    let new_logs = app
+        .list_logs(
+            &ctx,
+            &ListLogsInput {
+                dates: vec![],
+                levels: vec![],
+                resource: None,
+            },
+        )
+        .await
+        .unwrap()
+        .contents;
+    assert_eq!(new_logs.len(), 14);
+    cleanup().await;
+}
 
-//     let new_logs = app
-//         .list_logs(
-//             &ctx,
-//             &ListLogsInput {
-//                 dates: vec![],
-//                 levels: vec![],
-//                 resource: None,
-//             },
-//         )
-//         .await
-//         .unwrap()
-//         .contents;
-//     assert_eq!(new_logs.len(), 14);
-//     cleanup().await;
-// }
+#[tokio::test]
+async fn test_delete_all_logs() {
+    let (app, ctx, cleanup) = set_up_test_app().await;
 
-// #[tokio::test]
-// async fn test_delete_all_logs() {
-//     let (app, ctx, services, cleanup, _abs_path) = set_up_test_app().await;
-//     let log_service = services.get::<LogService<MockAppRuntime>>();
+    for _ in 0..15 {
+        warn(
+            LogScope::App,
+            LogPayload {
+                resource: None,
+                message: "".to_string(),
+            },
+        );
+    }
 
-//     for _ in 0..15 {
-//         log_service.warn(
-//             LogScope::App,
-//             LogPayload {
-//                 resource: None,
-//                 message: "".to_string(),
-//             },
-//         );
-//     }
+    // Wait for all writes to finish
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
 
-//     // Wait for all writes to finish
-//     tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+    let logs = app
+        .list_logs(
+            &ctx,
+            &ListLogsInput {
+                dates: vec![],
+                levels: vec![],
+                resource: None,
+            },
+        )
+        .await
+        .unwrap()
+        .contents;
 
-//     let logs = app
-//         .list_logs(
-//             &ctx,
-//             &ListLogsInput {
-//                 dates: vec![],
-//                 levels: vec![],
-//                 resource: None,
-//             },
-//         )
-//         .await
-//         .unwrap()
-//         .contents;
+    let input = BatchDeleteLogInput {
+        ids: logs.into_iter().map(|log| log.id.clone()).collect(),
+    };
 
-//     let input = BatchDeleteLogInput {
-//         ids: logs.into_iter().map(|log| log.id.clone()).collect(),
-//     };
+    let output = app.batch_delete_log(&ctx, &input).await.unwrap();
+    let deleted_entries = output.deleted_entries;
+    assert_eq!(deleted_entries.len(), 15);
 
-//     let output = app.batch_delete_log(&ctx, &input).await.unwrap();
-//     let deleted_entries = output.deleted_entries;
-//     assert_eq!(deleted_entries.len(), 15);
+    let new_logs = app
+        .list_logs(
+            &ctx,
+            &ListLogsInput {
+                dates: vec![],
+                levels: vec![],
+                resource: None,
+            },
+        )
+        .await
+        .unwrap()
+        .contents;
+    assert!(new_logs.is_empty());
 
-//     let new_logs = app
-//         .list_logs(
-//             &ctx,
-//             &ListLogsInput {
-//                 dates: vec![],
-//                 levels: vec![],
-//                 resource: None,
-//             },
-//         )
-//         .await
-//         .unwrap()
-//         .contents;
-//     assert!(new_logs.is_empty());
-
-//     cleanup().await;
-// }
+    cleanup().await;
+}

--- a/crates/moss-app/tests/app__cancel_request.rs
+++ b/crates/moss-app/tests/app__cancel_request.rs
@@ -1,148 +1,148 @@
 // FIXME: These tests are temporarily commented out because we need to rethink our approach to log management.
 
-// #![cfg(feature = "integration-tests")]
+#![cfg(feature = "integration-tests")]
 
-// use futures::future;
-// use moss_app::models::operations::CancelRequestInput;
-// use moss_applib::context::{AnyAsyncContext, AnyContext, MutableContext, Reason};
-// use std::time::Duration;
-// use tokio::time::timeout;
+use futures::future;
+use moss_app::models::operations::CancelRequestInput;
+use moss_applib::context::{AnyAsyncContext, AnyContext, MutableContext, Reason};
+use std::time::Duration;
+use tokio::time::timeout;
 
-// use crate::shared::set_up_test_app;
-// mod shared;
+use crate::shared::set_up_test_app;
+mod shared;
 
-// #[tokio::test]
-// async fn cancel_request_success() {
-//     let (app, _top_ctx, _services, cleanup, _abs_path) = set_up_test_app().await;
+#[tokio::test]
+async fn cancel_request_success() {
+    let (app, _ctx, cleanup) = set_up_test_app().await;
 
-//     let ctx = MutableContext::background();
-//     let request_id = "request".to_string();
+    let ctx = MutableContext::background();
+    let request_id = "request".to_string();
 
-//     let cancellation_map = app.cancellation_map();
+    let cancellation_map = app.cancellation_map();
 
-//     cancellation_map
-//         .write()
-//         .await
-//         .insert(request_id.clone(), ctx.get_canceller());
+    cancellation_map
+        .write()
+        .await
+        .insert(request_id.clone(), ctx.get_canceller());
 
-//     let ctx = ctx.freeze();
-//     let (canceled_tx, canceled_rx) = tokio::sync::oneshot::channel();
+    let ctx = ctx.freeze();
+    let (canceled_tx, canceled_rx) = tokio::sync::oneshot::channel();
 
-//     {
-//         let ctx = ctx.clone();
-//         tokio::spawn(async move {
-//             loop {
-//                 if matches!(ctx.done(), Some(Reason::Canceled)) {
-//                     eprintln!("Background task cancelled");
-//                     canceled_tx.send(true).unwrap();
-//                     return;
-//                 }
-//                 eprintln!("Background task running");
-//                 tokio::time::sleep(Duration::from_millis(100)).await;
-//             }
-//         });
-//     }
-//     tokio::time::sleep(Duration::from_millis(1000)).await;
+    {
+        let ctx = ctx.clone();
+        tokio::spawn(async move {
+            loop {
+                if matches!(ctx.done(), Some(Reason::Canceled)) {
+                    eprintln!("Background task cancelled");
+                    canceled_tx.send(true).unwrap();
+                    return;
+                }
+                eprintln!("Background task running");
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        });
+    }
+    tokio::time::sleep(Duration::from_millis(1000)).await;
 
-//     app.cancel_request(CancelRequestInput { request_id })
-//         .await
-//         .unwrap();
+    app.cancel_request(CancelRequestInput { request_id })
+        .await
+        .unwrap();
 
-//     if let Err(_) = timeout(Duration::from_secs(5), canceled_rx).await {
-//         panic!("Cancellation failed");
-//     } else {
-//         println!("Cancellation succeeded");
-//     }
+    if let Err(_) = timeout(Duration::from_secs(5), canceled_rx).await {
+        panic!("Cancellation failed");
+    } else {
+        println!("Cancellation succeeded");
+    }
 
-//     cleanup().await;
-// }
+    cleanup().await;
+}
 
-// #[tokio::test]
-// async fn cancel_request_nonexistent() {
-//     let (app, _top_ctx, _services, cleanup, _abs_path) = set_up_test_app().await;
+#[tokio::test]
+async fn cancel_request_nonexistent() {
+    let (app, _ctx, cleanup) = set_up_test_app().await;
 
-//     let request_id = "nonexistent".to_string();
+    let request_id = "nonexistent".to_string();
 
-//     assert!(
-//         app.cancel_request(CancelRequestInput { request_id })
-//             .await
-//             .is_err()
-//     );
+    assert!(
+        app.cancel_request(CancelRequestInput { request_id })
+            .await
+            .is_err()
+    );
 
-//     cleanup().await;
-// }
+    cleanup().await;
+}
 
-// #[tokio::test]
-// async fn cancel_request_with_child() {
-//     let (app, _top_ctx, _services, cleanup, _abs_path) = set_up_test_app().await;
+#[tokio::test]
+async fn cancel_request_with_child() {
+    let (app, _ctx, cleanup) = set_up_test_app().await;
 
-//     let cancellation_map = app.cancellation_map();
+    let cancellation_map = app.cancellation_map();
 
-//     let parent_ctx = MutableContext::background();
-//     let parent_id = "parent".to_string();
+    let parent_ctx = MutableContext::background();
+    let parent_id = "parent".to_string();
 
-//     cancellation_map
-//         .write()
-//         .await
-//         .insert(parent_id.clone(), parent_ctx.get_canceller());
+    cancellation_map
+        .write()
+        .await
+        .insert(parent_id.clone(), parent_ctx.get_canceller());
 
-//     let (parent_canceled_tx, parent_canceled_rx) = tokio::sync::oneshot::channel();
-//     let (child_canceled_tx, child_canceled_rx) = tokio::sync::oneshot::channel();
-//     {
-//         let cancellation_map = cancellation_map.clone();
-//         let parent_ctx = parent_ctx.freeze();
-//         tokio::spawn(async move {
-//             let child_ctx = AnyAsyncContext::new(parent_ctx.clone());
-//             let child_id = "child".to_string();
-//             cancellation_map
-//                 .write()
-//                 .await
-//                 .insert(child_id.clone(), child_ctx.get_canceller());
-//             {
-//                 let child_ctx = child_ctx.freeze();
+    let (parent_canceled_tx, parent_canceled_rx) = tokio::sync::oneshot::channel();
+    let (child_canceled_tx, child_canceled_rx) = tokio::sync::oneshot::channel();
+    {
+        let cancellation_map = cancellation_map.clone();
+        let parent_ctx = parent_ctx.freeze();
+        tokio::spawn(async move {
+            let child_ctx = AnyAsyncContext::new(parent_ctx.clone());
+            let child_id = "child".to_string();
+            cancellation_map
+                .write()
+                .await
+                .insert(child_id.clone(), child_ctx.get_canceller());
+            {
+                let child_ctx = child_ctx.freeze();
 
-//                 // Child Context
-//                 tokio::spawn(async move {
-//                     loop {
-//                         if matches!(child_ctx.done(), Some(Reason::Canceled)) {
-//                             eprintln!("Child task cancelled");
-//                             child_canceled_tx.send(true).unwrap();
-//                             return;
-//                         }
-//                         eprintln!("Child task running");
-//                         tokio::time::sleep(Duration::from_millis(100)).await;
-//                     }
-//                 });
-//             }
+                // Child Context
+                tokio::spawn(async move {
+                    loop {
+                        if matches!(child_ctx.done(), Some(Reason::Canceled)) {
+                            eprintln!("Child task cancelled");
+                            child_canceled_tx.send(true).unwrap();
+                            return;
+                        }
+                        eprintln!("Child task running");
+                        tokio::time::sleep(Duration::from_millis(100)).await;
+                    }
+                });
+            }
 
-//             // Parent Context
-//             loop {
-//                 if matches!(parent_ctx.done(), Some(Reason::Canceled)) {
-//                     eprintln!("Parent task cancelled");
-//                     parent_canceled_tx.send(true).unwrap();
-//                     return;
-//                 }
-//                 eprintln!("Parent task running");
-//                 tokio::time::sleep(Duration::from_millis(100)).await;
-//             }
-//         });
-//     }
+            // Parent Context
+            loop {
+                if matches!(parent_ctx.done(), Some(Reason::Canceled)) {
+                    eprintln!("Parent task cancelled");
+                    parent_canceled_tx.send(true).unwrap();
+                    return;
+                }
+                eprintln!("Parent task running");
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        });
+    }
 
-//     tokio::time::sleep(Duration::from_millis(1000)).await;
-//     app.cancel_request(CancelRequestInput {
-//         request_id: parent_id,
-//     })
-//     .await
-//     .unwrap();
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+    app.cancel_request(CancelRequestInput {
+        request_id: parent_id,
+    })
+    .await
+    .unwrap();
 
-//     // Cancelling the parent context should also cancel the child context
-//     let canceled_fut = future::join(parent_canceled_rx, child_canceled_rx);
+    // Cancelling the parent context should also cancel the child context
+    let canceled_fut = future::join(parent_canceled_rx, child_canceled_rx);
 
-//     if let Err(_) = timeout(Duration::from_secs(5), canceled_fut).await {
-//         panic!("Cancellation failed");
-//     } else {
-//         println!("Cancellation succeeded");
-//     }
+    if let Err(_) = timeout(Duration::from_secs(5), canceled_fut).await {
+        panic!("Cancellation failed");
+    } else {
+        println!("Cancellation succeeded");
+    }
 
-//     cleanup().await;
-// }
+    cleanup().await;
+}

--- a/crates/moss-app/tests/app__close_workspace.rs
+++ b/crates/moss-app/tests/app__close_workspace.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "integration-tests")]
+
 pub mod shared;
 
 use moss_app::{

--- a/crates/moss-app/tests/app__create_workspace.rs
+++ b/crates/moss-app/tests/app__create_workspace.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "integration-tests")]
+
 pub mod shared;
 
 use moss_app::{

--- a/crates/moss-app/tests/app__delete_workspace.rs
+++ b/crates/moss-app/tests/app__delete_workspace.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "integration-tests")]
+
 pub mod shared;
 
 use moss_app::{

--- a/crates/moss-app/tests/app__list_logs.rs
+++ b/crates/moss-app/tests/app__list_logs.rs
@@ -6,7 +6,7 @@ use chrono::{DateTime, FixedOffset};
 use moss_app::models::{operations::ListLogsInput, primitives::LogLevel};
 
 use crate::shared::set_up_test_app;
-use moss_logging::{LogPayload, LogScope, debug, error, warn};
+use moss_logging::{LogEvent, LogScope, debug, error, warn};
 use std::{str::FromStr, time::Duration};
 
 /// These tests can work one at a time, but cannot be executed together using `cargo test`.
@@ -50,14 +50,14 @@ async fn test_list_logs_from_both_files_and_queue() {
     for _ in 0..25 {
         warn(
             LogScope::App,
-            LogPayload {
+            LogEvent {
                 resource: None,
                 message: "".to_string(),
             },
         );
         warn(
             LogScope::Session,
-            LogPayload {
+            LogEvent {
                 resource: None,
                 message: "".to_string(),
             },
@@ -96,21 +96,21 @@ async fn test_list_logs_by_level() {
 
     debug(
         LogScope::App,
-        LogPayload {
+        LogEvent {
             resource: None,
             message: "".to_string(),
         },
     );
     warn(
         LogScope::App,
-        LogPayload {
+        LogEvent {
             resource: None,
             message: "".to_string(),
         },
     );
     error(
         LogScope::App,
-        LogPayload {
+        LogEvent {
             resource: None,
             message: "".to_string(),
         },
@@ -169,21 +169,21 @@ async fn test_list_logs_by_resource() {
 
     debug(
         LogScope::App,
-        LogPayload {
+        LogEvent {
             resource: None,
             message: "".to_string(),
         },
     );
     debug(
         LogScope::App,
-        LogPayload {
+        LogEvent {
             resource: Some("resource".to_string()),
             message: "".to_string(),
         },
     );
     debug(
         LogScope::App,
-        LogPayload {
+        LogEvent {
             resource: Some("another".to_string()),
             message: "".to_string(),
         },

--- a/crates/moss-app/tests/app__list_logs.rs
+++ b/crates/moss-app/tests/app__list_logs.rs
@@ -1,214 +1,208 @@
-// FIXME: These tests are temporarily commented out because we need to rethink our approach to log management.
+#![cfg(feature = "integration-tests")]
 
-// pub mod shared;
+pub mod shared;
 
-// use chrono::{DateTime, FixedOffset};
-// use moss_app::{
-//     models::{operations::ListLogsInput, primitives::LogLevel},
-//     services::log_service::{LogPayload, LogScope},
-// };
+use chrono::{DateTime, FixedOffset};
+use moss_app::models::{operations::ListLogsInput, primitives::LogLevel};
 
-// use std::{str::FromStr, time::Duration};
+use crate::shared::set_up_test_app;
+use moss_logging::{LogPayload, LogScope, debug, error, warn};
+use std::{str::FromStr, time::Duration};
 
-// use crate::shared::set_up_test_app;
+/// These tests can work one at a time, but cannot be executed together using `cargo test`.
+/// This is because LoggingService will set a global default subscriber.
+/// However, it can only be set once per a program,
+/// While the `cargo test` model will run every test as part of the same program.
+/// Thus, they are marked as ignored.
 
-// /// These tests can work one at a time, but cannot be executed together using `cargo test`.
-// /// This is because LoggingService will set a global default subscriber.
-// /// However, it can only be set once per a program,
-// /// While the `cargo test` model will run every test as part of the same program.
-// /// Thus, they are marked as ignored.
+// We can't test dates filter now since we can't generate logs with custom dates
 
-// // We can't test dates filter now since we can't generate logs with custom dates
+#[ignore]
+#[tokio::test]
+async fn test_list_logs_empty() {
+    let (app, ctx, cleanup) = set_up_test_app().await;
 
-// #[ignore]
-// #[tokio::test]
-// async fn test_list_logs_empty() {
-//     let (app, ctx, cleanup) = set_up_test_app().await;
-//     // let _log_service = services.get::<LogService<MockAppRuntime>>();
+    let list_logs_result = app
+        .list_logs(
+            &ctx,
+            &ListLogsInput {
+                dates: vec![],
+                levels: vec![],
+                resource: None,
+            },
+        )
+        .await;
 
-//     let list_logs_result = app
-//         .list_logs(
-//             &ctx,
-//             &ListLogsInput {
-//                 dates: vec![],
-//                 levels: vec![],
-//                 resource: None,
-//             },
-//         )
-//         .await;
+    assert!(list_logs_result.is_ok());
+    let logs = list_logs_result.unwrap().contents;
+    assert!(logs.is_empty());
 
-//     assert!(list_logs_result.is_ok());
-//     let logs = list_logs_result.unwrap().contents;
-//     assert!(logs.is_empty());
+    cleanup().await;
+}
 
-//     cleanup().await;
-// }
+#[ignore]
+#[tokio::test]
+async fn test_list_logs_from_both_files_and_queue() {
+    // By default, the applong and session log queue will be flushed to files for every ten log
+    // We will create 25 of each to see that the logs are successfully combined
+    let (app, ctx, cleanup) = set_up_test_app().await;
 
-// #[ignore]
-// #[tokio::test]
-// async fn test_list_logs_from_both_files_and_queue() {
-//     // By default, the applong and session log queue will be flushed to files for every ten log
-//     // We will create 25 of each to see that the logs are successfully combined
-//     let (app, ctx, cleanup) = set_up_test_app().await;
-//     let log_service = services.get::<LogService<MockAppRuntime>>();
+    for _ in 0..25 {
+        warn(
+            LogScope::App,
+            LogPayload {
+                resource: None,
+                message: "".to_string(),
+            },
+        );
+        warn(
+            LogScope::Session,
+            LogPayload {
+                resource: None,
+                message: "".to_string(),
+            },
+        );
+    }
 
-//     for _ in 0..25 {
-//         log_service.warn(
-//             LogScope::App,
-//             LogPayload {
-//                 resource: None,
-//                 message: "".to_string(),
-//             },
-//         );
-//         log_service.warn(
-//             LogScope::Session,
-//             LogPayload {
-//                 resource: None,
-//                 message: "".to_string(),
-//             },
-//         );
-//     }
+    // Wait for all writes to finish
+    tokio::time::sleep(Duration::from_millis(500)).await;
 
-//     // Wait for all writes to finish
-//     tokio::time::sleep(Duration::from_millis(500)).await;
+    let list_logs_output = app
+        .list_logs(
+            &ctx,
+            &ListLogsInput {
+                dates: vec![],
+                levels: vec![],
+                resource: None,
+            },
+        )
+        .await
+        .unwrap();
 
-//     let list_logs_output = app
-//         .list_logs(
-//             &ctx,
-//             &ListLogsInput {
-//                 dates: vec![],
-//                 levels: vec![],
-//                 resource: None,
-//             },
-//         )
-//         .await
-//         .unwrap();
+    let logs = list_logs_output.contents;
+    assert_eq!(logs.len(), 50);
+    // Check that the output logs are sorted chronologically
+    assert!(
+        logs.is_sorted_by_key(|log| DateTime::<FixedOffset>::from_str(&log.timestamp).unwrap())
+    );
 
-//     let logs = list_logs_output.contents;
-//     assert_eq!(logs.len(), 50);
-//     // Check that the output logs are sorted chronologically
-//     assert!(
-//         logs.is_sorted_by_key(|log| DateTime::<FixedOffset>::from_str(&log.timestamp).unwrap())
-//     );
+    cleanup().await;
+}
 
-//     cleanup().await;
-// }
+#[ignore]
+#[tokio::test]
+async fn test_list_logs_by_level() {
+    let (app, ctx, cleanup) = set_up_test_app().await;
 
-// #[ignore]
-// #[tokio::test]
-// async fn test_list_logs_by_level() {
-//     let (app, ctx, cleanup) = set_up_test_app().await;
-//     // let log_service = services.get::<LogService<MockAppRuntime>>();
+    debug(
+        LogScope::App,
+        LogPayload {
+            resource: None,
+            message: "".to_string(),
+        },
+    );
+    warn(
+        LogScope::App,
+        LogPayload {
+            resource: None,
+            message: "".to_string(),
+        },
+    );
+    error(
+        LogScope::App,
+        LogPayload {
+            resource: None,
+            message: "".to_string(),
+        },
+    );
 
-//     log_service.debug(
-//         LogScope::App,
-//         LogPayload {
-//             resource: None,
-//             message: "".to_string(),
-//         },
-//     );
-//     log_service.warn(
-//         LogScope::App,
-//         LogPayload {
-//             resource: None,
-//             message: "".to_string(),
-//         },
-//     );
-//     log_service.error(
-//         LogScope::App,
-//         LogPayload {
-//             resource: None,
-//             message: "".to_string(),
-//         },
-//     );
+    let debug_logs = app
+        .list_logs(
+            &ctx,
+            &ListLogsInput {
+                dates: vec![],
+                levels: vec![LogLevel::DEBUG],
+                resource: None,
+            },
+        )
+        .await
+        .unwrap()
+        .contents;
+    assert_eq!(debug_logs.len(), 1);
 
-//     let debug_logs = app
-//         .list_logs(
-//             &ctx,
-//             &ListLogsInput {
-//                 dates: vec![],
-//                 levels: vec![LogLevel::DEBUG],
-//                 resource: None,
-//             },
-//         )
-//         .await
-//         .unwrap()
-//         .contents;
-//     assert_eq!(debug_logs.len(), 1);
+    let warn_logs = app
+        .list_logs(
+            &ctx,
+            &ListLogsInput {
+                dates: vec![],
+                levels: vec![LogLevel::WARN],
+                resource: None,
+            },
+        )
+        .await
+        .unwrap()
+        .contents;
+    assert_eq!(warn_logs.len(), 1);
 
-//     let warn_logs = app
-//         .list_logs(
-//             &ctx,
-//             &ListLogsInput {
-//                 dates: vec![],
-//                 levels: vec![LogLevel::WARN],
-//                 resource: None,
-//             },
-//         )
-//         .await
-//         .unwrap()
-//         .contents;
-//     assert_eq!(warn_logs.len(), 1);
+    let error_logs = app
+        .list_logs(
+            &ctx,
+            &ListLogsInput {
+                dates: vec![],
+                levels: vec![LogLevel::ERROR],
+                resource: None,
+            },
+        )
+        .await
+        .unwrap()
+        .contents;
+    assert_eq!(error_logs.len(), 1);
 
-//     let error_logs = app
-//         .list_logs(
-//             &ctx,
-//             &ListLogsInput {
-//                 dates: vec![],
-//                 levels: vec![LogLevel::ERROR],
-//                 resource: None,
-//             },
-//         )
-//         .await
-//         .unwrap()
-//         .contents;
-//     assert_eq!(error_logs.len(), 1);
+    cleanup().await;
+}
 
-//     cleanup().await;
-// }
+#[ignore]
+#[tokio::test]
+async fn test_list_logs_by_resource() {
+    let (app, ctx, cleanup) = set_up_test_app().await;
+    // let log_service = services.get::<LogService<MockAppRuntime>>();
 
-// #[ignore]
-// #[tokio::test]
-// async fn test_list_logs_by_resource() {
-//     let (app, ctx, cleanup) = set_up_test_app().await;
-//     // let log_service = services.get::<LogService<MockAppRuntime>>();
+    debug(
+        LogScope::App,
+        LogPayload {
+            resource: None,
+            message: "".to_string(),
+        },
+    );
+    debug(
+        LogScope::App,
+        LogPayload {
+            resource: Some("resource".to_string()),
+            message: "".to_string(),
+        },
+    );
+    debug(
+        LogScope::App,
+        LogPayload {
+            resource: Some("another".to_string()),
+            message: "".to_string(),
+        },
+    );
 
-//     log_service.debug(
-//         LogScope::App,
-//         LogPayload {
-//             resource: None,
-//             message: "".to_string(),
-//         },
-//     );
-//     log_service.debug(
-//         LogScope::App,
-//         LogPayload {
-//             resource: Some("resource".to_string()),
-//             message: "".to_string(),
-//         },
-//     );
-//     log_service.debug(
-//         LogScope::App,
-//         LogPayload {
-//             resource: Some("another".to_string()),
-//             message: "".to_string(),
-//         },
-//     );
+    let resource_logs = app
+        .list_logs(
+            &ctx,
+            &ListLogsInput {
+                dates: vec![],
+                levels: vec![],
+                resource: Some("resource".to_string()),
+            },
+        )
+        .await
+        .unwrap()
+        .contents;
 
-//     let resource_logs = app
-//         .list_logs(
-//             &ctx,
-//             &ListLogsInput {
-//                 dates: vec![],
-//                 levels: vec![],
-//                 resource: Some("resource".to_string()),
-//             },
-//         )
-//         .await
-//         .unwrap()
-//         .contents;
+    assert_eq!(resource_logs.len(), 1);
 
-//     assert_eq!(resource_logs.len(), 1);
-
-//     cleanup().await;
-// }
+    cleanup().await;
+}

--- a/crates/moss-app/tests/app__open_workspace.rs
+++ b/crates/moss-app/tests/app__open_workspace.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "integration-tests")]
+
 pub mod shared;
 
 use moss_app::{

--- a/crates/moss-app/tests/app__rename_workspace.rs
+++ b/crates/moss-app/tests/app__rename_workspace.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "integration-tests")]
 pub mod shared;
 
 use moss_app::models::operations::{CreateWorkspaceInput, UpdateWorkspaceInput};

--- a/crates/moss-logging/Cargo.toml
+++ b/crates/moss-logging/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "moss_logging"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+tracing.workspace = true
+ts-rs.workspace = true
+serde = { workspace = true, features = ["derive", "rc"] }
+derive_more = { workspace = true, features = ["deref"] }
+nanoid.workspace = true
+
+[features]
+integration-tests = []

--- a/crates/moss-logging/LICENSE-MIT
+++ b/crates/moss-logging/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/crates/moss-logging/src/lib.rs
+++ b/crates/moss-logging/src/lib.rs
@@ -11,7 +11,9 @@ pub mod constants {
     pub const SESSION_SCOPE: &'static str = "session";
 }
 
-pub struct LogPayload {
+pub struct LogEvent {
+    // FIXME: We might want to support a set of identifiers
+    // Including CollectionID, EntryID and EnvironmentID
     pub resource: Option<String>,
     pub message: String,
 }
@@ -23,7 +25,7 @@ pub enum LogScope {
 
 // Tracing disallows non-constant value for `target`
 // So we have to manually match it
-pub fn trace(scope: LogScope, payload: LogPayload) {
+pub fn trace(scope: LogScope, payload: LogEvent) {
     let id = LogEntryId::new().to_string();
     match scope {
         LogScope::App => {
@@ -45,7 +47,7 @@ pub fn trace(scope: LogScope, payload: LogPayload) {
     }
 }
 
-pub fn debug(scope: LogScope, payload: LogPayload) {
+pub fn debug(scope: LogScope, payload: LogEvent) {
     let id = LogEntryId::new().to_string();
     match scope {
         LogScope::App => {
@@ -67,7 +69,7 @@ pub fn debug(scope: LogScope, payload: LogPayload) {
     }
 }
 
-pub fn info(scope: LogScope, payload: LogPayload) {
+pub fn info(scope: LogScope, payload: LogEvent) {
     let id = LogEntryId::new().to_string();
     match scope {
         LogScope::App => {
@@ -89,7 +91,7 @@ pub fn info(scope: LogScope, payload: LogPayload) {
     }
 }
 
-pub fn warn(scope: LogScope, payload: LogPayload) {
+pub fn warn(scope: LogScope, payload: LogEvent) {
     let id = LogEntryId::new().to_string();
     match scope {
         LogScope::App => {
@@ -111,7 +113,7 @@ pub fn warn(scope: LogScope, payload: LogPayload) {
     }
 }
 
-pub fn error(scope: LogScope, payload: LogPayload) {
+pub fn error(scope: LogScope, payload: LogEvent) {
     let id = LogEntryId::new().to_string();
     match scope {
         LogScope::App => {

--- a/crates/moss-logging/src/lib.rs
+++ b/crates/moss-logging/src/lib.rs
@@ -1,0 +1,134 @@
+use crate::{
+    constants::{APP_SCOPE, SESSION_SCOPE},
+    models::primitives::LogEntryId,
+};
+use tracing::{debug, error, info, trace, warn};
+
+pub mod models;
+
+pub mod constants {
+    pub const APP_SCOPE: &'static str = "app";
+    pub const SESSION_SCOPE: &'static str = "session";
+}
+
+pub struct LogPayload {
+    pub resource: Option<String>,
+    pub message: String,
+}
+
+pub enum LogScope {
+    App,
+    Session,
+}
+
+// Tracing disallows non-constant value for `target`
+// So we have to manually match it
+pub fn trace(scope: LogScope, payload: LogPayload) {
+    let id = LogEntryId::new().to_string();
+    match scope {
+        LogScope::App => {
+            trace!(
+                target: APP_SCOPE,
+                id = id,
+                resource = payload.resource,
+                message = payload.message
+            )
+        }
+        LogScope::Session => {
+            trace!(
+                target: SESSION_SCOPE,
+                id = id,
+                resource = payload.resource,
+                message = payload.message
+            )
+        }
+    }
+}
+
+pub fn debug(scope: LogScope, payload: LogPayload) {
+    let id = LogEntryId::new().to_string();
+    match scope {
+        LogScope::App => {
+            debug!(
+                target: APP_SCOPE,
+                id = id,
+                resource = payload.resource,
+                message = payload.message
+            )
+        }
+        LogScope::Session => {
+            debug!(
+                target: SESSION_SCOPE,
+                id = id,
+                resource = payload.resource,
+                message = payload.message
+            )
+        }
+    }
+}
+
+pub fn info(scope: LogScope, payload: LogPayload) {
+    let id = LogEntryId::new().to_string();
+    match scope {
+        LogScope::App => {
+            info!(
+                target: APP_SCOPE,
+                id = id,
+                resource = payload.resource,
+                message = payload.message
+            )
+        }
+        LogScope::Session => {
+            info!(
+                target: SESSION_SCOPE,
+                id = id,
+                resource = payload.resource,
+                message = payload.message
+            )
+        }
+    }
+}
+
+pub fn warn(scope: LogScope, payload: LogPayload) {
+    let id = LogEntryId::new().to_string();
+    match scope {
+        LogScope::App => {
+            warn!(
+                target: APP_SCOPE,
+                id = id,
+                resource = payload.resource,
+                message = payload.message
+            )
+        }
+        LogScope::Session => {
+            warn!(
+                target: SESSION_SCOPE,
+                id = id,
+                resource = payload.resource,
+                message = payload.message
+            )
+        }
+    }
+}
+
+pub fn error(scope: LogScope, payload: LogPayload) {
+    let id = LogEntryId::new().to_string();
+    match scope {
+        LogScope::App => {
+            error!(
+                target: APP_SCOPE,
+                id = id,
+                resource = payload.resource,
+                message = payload.message
+            )
+        }
+        LogScope::Session => {
+            error!(
+                target: SESSION_SCOPE,
+                id = id,
+                resource = payload.resource,
+                message = payload.message
+            )
+        }
+    }
+}

--- a/crates/moss-logging/src/models.rs
+++ b/crates/moss-logging/src/models.rs
@@ -1,0 +1,1 @@
+pub mod primitives;

--- a/crates/moss-logging/src/models/primitives.rs
+++ b/crates/moss-logging/src/models/primitives.rs
@@ -1,0 +1,31 @@
+use derive_more::Deref;
+use nanoid::nanoid;
+use serde::{Deserialize, Serialize};
+use std::{fmt::Display, sync::Arc};
+
+#[derive(Clone, Debug, PartialEq, Hash, Eq, Deref, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct LogEntryId(Arc<String>);
+impl LogEntryId {
+    pub fn new() -> Self {
+        Self(Arc::new(nanoid!(10)))
+    }
+}
+
+impl From<String> for LogEntryId {
+    fn from(s: String) -> Self {
+        Self(Arc::new(s))
+    }
+}
+
+impl AsRef<str> for LogEntryId {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl Display for LogEntryId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/libs/joinerror/src/ext.rs
+++ b/libs/joinerror/src/ext.rs
@@ -13,6 +13,12 @@ impl From<std::io::Error> for Error {
     }
 }
 
+impl<T> From<std::sync::PoisonError<T>> for Error {
+    fn from(err: std::sync::PoisonError<T>) -> Self {
+        Error::new::<()>("mutex poisoned").join(err.to_string())
+    }
+}
+
 impl From<reqwest::Error> for Error {
     fn from(err: reqwest::Error) -> Self {
         Error::new::<()>(err.to_string())

--- a/libs/joinerror/src/ext.rs
+++ b/libs/joinerror/src/ext.rs
@@ -15,7 +15,7 @@ impl From<std::io::Error> for Error {
 
 impl<T> From<std::sync::PoisonError<T>> for Error {
     fn from(err: std::sync::PoisonError<T>) -> Self {
-        Error::new::<()>("mutex poisoned").join(err.to_string())
+        Error::new::<()>("mutex poisoned").join::<()>(err.to_string())
     }
 }
 

--- a/view/desktop/bin/src/plugins.rs
+++ b/view/desktop/bin/src/plugins.rs
@@ -8,6 +8,10 @@ pub mod plugin_log {
     use super::*;
 
     pub fn init<R: Runtime>() -> TauriPlugin<R> {
+        // FIXME: Very weird that we can disable `reqwest` logs here but not at tracing subscribers
+        // Apparently `reqwest` does not generate `tracing` logs
+        // And the dispatching of `log` logs to `tracing` does not work correctly
+
         tauri_plugin_log::Builder::default()
             .targets([
                 Target::new(TargetKind::Stdout),
@@ -17,6 +21,8 @@ pub mod plugin_log {
             .level_for("tao", log::LevelFilter::Info)
             .level_for("plugin_runtime", log::LevelFilter::Info)
             .level_for("tracing", log::LevelFilter::Warn)
+            .level_for("mio", log::LevelFilter::Off)
+            .level_for("reqwest", log::LevelFilter::Off)
             .with_colors(ColoredLevelConfig::default())
             .level(if is_dev() {
                 log::LevelFilter::Trace


### PR DESCRIPTION
1. Extract functions that generate logs into a separate `moss-logging` crate, and make `LogService` in `moss-app` only responsible for querying and deleting logs
2. Introduce joinerror to log operations.