### PR TITLE
fix(SAPIC-474): Workspace loading issue

### DIFF
--- a/crates/moss-collection/src/builder.rs
+++ b/crates/moss-collection/src/builder.rs
@@ -185,6 +185,11 @@ impl CollectionBuilder {
             .join_err::<()>("failed to create collection storage service")?
             .into();
 
+        // Create expandedEntries key in the database to prevent warnings
+        storage_service
+            .put_expanded_entries(ctx, Vec::new())
+            .await?;
+
         let worktree_service: Arc<Worktree<R>> =
             Worktree::new(abs_path.clone(), self.fs.clone(), storage_service.clone()).into();
 
@@ -313,7 +318,7 @@ impl CollectionBuilder {
 
     pub async fn clone<R: AppRuntime>(
         self,
-        _ctx: &R::AsyncContext,
+        ctx: &R::AsyncContext,
         params: CollectionCloneParams,
     ) -> joinerror::Result<Collection<R>> {
         debug_assert!(params.internal_abs_path.is_absolute());
@@ -334,6 +339,11 @@ impl CollectionBuilder {
         let storage_service: Arc<StorageService<R>> = StorageService::new(abs_path.as_ref())
             .join_err::<()>("failed to create collection storage service")?
             .into();
+
+        // Create expandedEntries key in the database to prevent warnings
+        storage_service
+            .put_expanded_entries(ctx, Vec::new())
+            .await?;
 
         let worktree: Arc<Worktree<R>> =
             Worktree::new(abs_path.clone(), self.fs.clone(), storage_service.clone()).into();

--- a/crates/moss-workspace/src/models/types.rs
+++ b/crates/moss-workspace/src/models/types.rs
@@ -188,7 +188,7 @@ pub struct ActivitybarPartStateInfo {
 #[ts(export, export_to = "types.ts")]
 pub struct SidebarPartStateInfo {
     pub position: SidebarPosition,
-    pub size: usize,
+    pub size: f64,
     pub visible: bool,
 }
 
@@ -201,7 +201,7 @@ pub struct SidebarPartStateInfo {
 #[serde(rename_all = "camelCase")]
 #[ts(export, export_to = "types.ts")]
 pub struct PanelPartStateInfo {
-    pub size: usize,
+    pub size: f64,
     pub visible: bool,
 }
 

--- a/crates/moss-workspace/src/services/layout_service.rs
+++ b/crates/moss-workspace/src/services/layout_service.rs
@@ -84,7 +84,7 @@ const ACTIVITYBAR_DEFAULTS: ActivitybarPartDefaults = ActivitybarPartDefaults {
 #[derive(Debug)]
 pub struct SidebarPartDefaults {
     position: SidebarPosition,
-    size: usize,
+    size: f64,
     is_visible: bool,
 }
 
@@ -96,7 +96,7 @@ pub struct SidebarPartPreferences {
 
 const SIDEBAR_DEFAULTS: SidebarPartDefaults = SidebarPartDefaults {
     position: SidebarPosition::Left,
-    size: 200,
+    size: 200.0,
     is_visible: true,
 };
 
@@ -106,7 +106,7 @@ const SIDEBAR_DEFAULTS: SidebarPartDefaults = SidebarPartDefaults {
 
 #[derive(Debug)]
 pub struct PanelPartDefaults {
-    size: usize,
+    size: f64,
     is_visible: bool,
 }
 
@@ -116,7 +116,7 @@ pub struct PanelPartPreferences {
 }
 
 const PANEL_DEFAULTS: PanelPartDefaults = PanelPartDefaults {
-    size: 200,
+    size: 200.0,
     is_visible: false,
 };
 
@@ -217,7 +217,7 @@ impl<R: AppRuntime> LayoutService<R> {
             .or(preferences.position)
             .unwrap_or(SIDEBAR_DEFAULTS.position),
 
-            size: get_from_cache::<usize>(cache, SEGKEY_LAYOUT_SIDEBAR.join("size"))
+            size: get_from_cache::<f64>(cache, SEGKEY_LAYOUT_SIDEBAR.join("size"))
                 .unwrap_or(SIDEBAR_DEFAULTS.size),
 
             visible: get_from_cache::<bool>(cache, SEGKEY_LAYOUT_SIDEBAR.join("visible"))
@@ -287,7 +287,7 @@ impl<R: AppRuntime> LayoutService<R> {
         let preferences = PanelPartPreferences { visible: None };
 
         Ok(PanelPartStateInfo {
-            size: get_from_cache::<usize>(cache, SEGKEY_LAYOUT_PANEL.join("size"))
+            size: get_from_cache::<f64>(cache, SEGKEY_LAYOUT_PANEL.join("size"))
                 .unwrap_or(PANEL_DEFAULTS.size),
 
             visible: get_from_cache::<bool>(cache, SEGKEY_LAYOUT_PANEL.join("visible"))

--- a/crates/moss-workspace/src/services/storage_service.rs
+++ b/crates/moss-workspace/src/services/storage_service.rs
@@ -200,7 +200,7 @@ impl<R: AppRuntime> StorageService<R> {
         &self,
         ctx: &R::AsyncContext,
         position: SidebarPosition,
-        size: usize,
+        size: f64,
         visible: bool,
     ) -> joinerror::Result<()> {
         let store = self.storage.item_store();
@@ -239,7 +239,7 @@ impl<R: AppRuntime> StorageService<R> {
     pub(super) async fn put_panel_layout(
         &self,
         ctx: &R::AsyncContext,
-        size: usize,
+        size: f64,
         visible: bool,
     ) -> joinerror::Result<()> {
         let store = self.storage.item_store();

--- a/crates/moss-workspace/tests/workspace__describe_state.rs
+++ b/crates/moss-workspace/tests/workspace__describe_state.rs
@@ -34,7 +34,7 @@ async fn describe_layout_parts_state_sidebar_only() {
 
     // Set up only the sidebar state
     let sidebar_state = SidebarPartStateInfo {
-        size: 250,
+        size: 250.0,
         visible: true,
         position: SidebarPosition::Left,
     };
@@ -60,7 +60,7 @@ async fn describe_layout_parts_state_sidebar_only() {
     // Sidebar should match the set value
     assert!(describe_state_output.sidebar.is_some());
     let retrieved_sidebar = describe_state_output.sidebar.unwrap();
-    assert_eq!(retrieved_sidebar.size, 250);
+    assert_eq!(retrieved_sidebar.size, 250.0);
     assert_eq!(retrieved_sidebar.visible, true);
     assert_eq!(retrieved_sidebar.position, SidebarPosition::Left);
 
@@ -73,7 +73,7 @@ async fn describe_layout_parts_state_panel_only() {
 
     // Set up only the panel state
     let panel_state = PanelPartStateInfo {
-        size: 200,
+        size: 200.0,
         visible: false,
     };
 
@@ -95,7 +95,7 @@ async fn describe_layout_parts_state_panel_only() {
     // Panel should match the set value
     assert!(describe_state_output.panel.is_some());
     let retrieved_panel = describe_state_output.panel.unwrap();
-    assert_eq!(retrieved_panel.size, 200);
+    assert_eq!(retrieved_panel.size, 200.0);
     assert_eq!(retrieved_panel.visible, false);
 
     cleanup().await;
@@ -126,12 +126,12 @@ async fn describe_layout_parts_state_all() {
 
     // Set up sidebar and panel states (no editor state since it's being removed)
     let sidebar_state = SidebarPartStateInfo {
-        size: 250,
+        size: 250.0,
         visible: true,
         position: SidebarPosition::Left,
     };
     let panel_state = PanelPartStateInfo {
-        size: 200,
+        size: 200.0,
         visible: false,
     };
 
@@ -158,13 +158,13 @@ async fn describe_layout_parts_state_all() {
     // Check Sidebar
     assert!(describe_state_output.sidebar.is_some());
     let retrieved_sidebar = describe_state_output.sidebar.unwrap();
-    assert_eq!(retrieved_sidebar.size, 250);
+    assert_eq!(retrieved_sidebar.size, 250.0);
     assert_eq!(retrieved_sidebar.visible, true);
 
     // Check Panel
     assert!(describe_state_output.panel.is_some());
     let retrieved_panel = describe_state_output.panel.unwrap();
-    assert_eq!(retrieved_panel.size, 200);
+    assert_eq!(retrieved_panel.size, 200.0);
     assert_eq!(retrieved_panel.visible, false);
 
     // Check Activitybar (should have default values)
@@ -179,12 +179,12 @@ async fn describe_layout_parts_state_after_update() {
 
     // First set sidebar and panel states (no editor state since it's being removed)
     let initial_sidebar_state = SidebarPartStateInfo {
-        size: 250,
+        size: 250.0,
         visible: true,
         position: SidebarPosition::Left,
     };
     let initial_panel_state = PanelPartStateInfo {
-        size: 200,
+        size: 200.0,
         visible: false,
     };
 
@@ -206,7 +206,7 @@ async fn describe_layout_parts_state_after_update() {
 
     // Now update only the sidebar
     let updated_sidebar_state = SidebarPartStateInfo {
-        size: 300,
+        size: 300.0,
         visible: false,
         position: SidebarPosition::Left,
     };
@@ -227,13 +227,13 @@ async fn describe_layout_parts_state_after_update() {
     // Sidebar should be updated
     assert!(describe_state_output.sidebar.is_some());
     let retrieved_sidebar = describe_state_output.sidebar.unwrap();
-    assert_eq!(retrieved_sidebar.size, 300); // Updated value
+    assert_eq!(retrieved_sidebar.size, 300.0); // Updated value
     assert_eq!(retrieved_sidebar.visible, false); // Updated value
 
     // Panel should not change
     assert!(describe_state_output.panel.is_some());
     let retrieved_panel = describe_state_output.panel.unwrap();
-    assert_eq!(retrieved_panel.size, 200);
+    assert_eq!(retrieved_panel.size, 200.0);
     assert_eq!(retrieved_panel.visible, false);
 
     cleanup().await;

--- a/crates/moss-workspace/tests/workspace__update_state.rs
+++ b/crates/moss-workspace/tests/workspace__update_state.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "integration-tests")]
 pub mod shared;
 
-use crate::shared::setup_test_workspace;
 use moss_storage::storage::operations::GetItem;
 use moss_workspace::{
     models::{
@@ -12,12 +11,13 @@ use moss_workspace::{
     storage::segments::{SEGKEY_LAYOUT_PANEL, SEGKEY_LAYOUT_SIDEBAR},
 };
 
+use crate::shared::setup_test_workspace;
 #[tokio::test]
 async fn update_state_sidebar_part() {
     let (ctx, workspace, cleanup) = setup_test_workspace().await;
 
     let sidebar_state = SidebarPartStateInfo {
-        size: 250,
+        size: 250.0,
         visible: true,
         position: SidebarPosition::Left,
     };
@@ -61,8 +61,8 @@ async fn update_state_sidebar_part() {
     )
     .await
     .unwrap();
-    let stored_size: usize = size_value.deserialize().unwrap();
-    assert_eq!(stored_size, 250);
+    let stored_size: f64 = size_value.deserialize().unwrap();
+    assert_eq!(stored_size, 250.0);
 
     // Check visible
     let visible_value = GetItem::get(
@@ -83,7 +83,7 @@ async fn update_state_panel_part() {
     let (ctx, workspace, cleanup) = setup_test_workspace().await;
 
     let panel_state = PanelPartStateInfo {
-        size: 200,
+        size: 200.0,
         visible: false,
     };
 
@@ -108,8 +108,8 @@ async fn update_state_panel_part() {
     let size_value = GetItem::get(item_store.as_ref(), &ctx, SEGKEY_LAYOUT_PANEL.join("size"))
         .await
         .unwrap();
-    let stored_size: usize = size_value.deserialize().unwrap();
-    assert_eq!(stored_size, 200);
+    let stored_size: f64 = size_value.deserialize().unwrap();
+    assert_eq!(stored_size, 200.0);
 
     // Check visible
     let visible_value = GetItem::get(
@@ -131,12 +131,12 @@ async fn update_state_multiple_updates() {
 
     // Initial states
     let sidebar_state = SidebarPartStateInfo {
-        size: 250,
+        size: 250.0,
         visible: true,
         position: SidebarPosition::Left,
     };
     let panel_state = PanelPartStateInfo {
-        size: 200,
+        size: 200.0,
         visible: false,
     };
 
@@ -177,7 +177,7 @@ async fn update_state_multiple_updates() {
     .unwrap();
     assert_eq!(sidebar_position, SidebarPosition::Left);
 
-    let sidebar_size: usize = GetItem::get(
+    let sidebar_size: f64 = GetItem::get(
         item_store.as_ref(),
         &ctx,
         SEGKEY_LAYOUT_SIDEBAR.join("size"),
@@ -186,7 +186,7 @@ async fn update_state_multiple_updates() {
     .unwrap()
     .deserialize()
     .unwrap();
-    assert_eq!(sidebar_size, 250);
+    assert_eq!(sidebar_size, 250.0);
 
     let sidebar_visible: bool = GetItem::get(
         item_store.as_ref(),
@@ -200,13 +200,12 @@ async fn update_state_multiple_updates() {
     assert_eq!(sidebar_visible, true);
 
     // Check panel values
-    let panel_size: usize =
-        GetItem::get(item_store.as_ref(), &ctx, SEGKEY_LAYOUT_PANEL.join("size"))
-            .await
-            .unwrap()
-            .deserialize()
-            .unwrap();
-    assert_eq!(panel_size, 200);
+    let panel_size: f64 = GetItem::get(item_store.as_ref(), &ctx, SEGKEY_LAYOUT_PANEL.join("size"))
+        .await
+        .unwrap()
+        .deserialize()
+        .unwrap();
+    assert_eq!(panel_size, 200.0);
 
     let panel_visible: bool = GetItem::get(
         item_store.as_ref(),
@@ -221,7 +220,7 @@ async fn update_state_multiple_updates() {
 
     // Update individual states
     let updated_sidebar_state = SidebarPartStateInfo {
-        size: 300,
+        size: 300.0,
         visible: false,
         position: SidebarPosition::Left,
     };
@@ -243,7 +242,7 @@ async fn update_state_multiple_updates() {
     assert_eq!(describe_state_output.panel.unwrap(), panel_state);
 
     // Verify the database reflects the updated sidebar values
-    let updated_sidebar_size: usize = GetItem::get(
+    let updated_sidebar_size: f64 = GetItem::get(
         item_store.as_ref(),
         &ctx,
         SEGKEY_LAYOUT_SIDEBAR.join("size"),
@@ -252,7 +251,7 @@ async fn update_state_multiple_updates() {
     .unwrap()
     .deserialize()
     .unwrap();
-    assert_eq!(updated_sidebar_size, 300);
+    assert_eq!(updated_sidebar_size, 300.0);
 
     let updated_sidebar_visible: bool = GetItem::get(
         item_store.as_ref(),
@@ -266,13 +265,13 @@ async fn update_state_multiple_updates() {
     assert_eq!(updated_sidebar_visible, false);
 
     // Panel values should remain unchanged
-    let panel_size_after: usize =
+    let panel_size_after: f64 =
         GetItem::get(item_store.as_ref(), &ctx, SEGKEY_LAYOUT_PANEL.join("size"))
             .await
             .unwrap()
             .deserialize()
             .unwrap();
-    assert_eq!(panel_size_after, 200);
+    assert_eq!(panel_size_after, 200.0);
 
     let panel_visible_after: bool = GetItem::get(
         item_store.as_ref(),
@@ -294,7 +293,7 @@ async fn update_state_overwrite_existing() {
 
     // Set initial state
     let initial_sidebar_state = SidebarPartStateInfo {
-        size: 250,
+        size: 250.0,
         visible: true,
         position: SidebarPosition::Left,
     };
@@ -309,7 +308,7 @@ async fn update_state_overwrite_existing() {
 
     // Verify initial state in database
     let item_store = workspace.db().item_store();
-    let initial_size: usize = GetItem::get(
+    let initial_size: f64 = GetItem::get(
         item_store.as_ref(),
         &ctx,
         SEGKEY_LAYOUT_SIDEBAR.join("size"),
@@ -318,7 +317,7 @@ async fn update_state_overwrite_existing() {
     .unwrap()
     .deserialize()
     .unwrap();
-    assert_eq!(initial_size, 250);
+    assert_eq!(initial_size, 250.0);
 
     let initial_visible: bool = GetItem::get(
         item_store.as_ref(),
@@ -333,7 +332,7 @@ async fn update_state_overwrite_existing() {
 
     // Update with new state
     let updated_sidebar_state = SidebarPartStateInfo {
-        size: 300,
+        size: 300.0,
         visible: false,
         position: SidebarPosition::Left,
     };
@@ -354,7 +353,7 @@ async fn update_state_overwrite_existing() {
     );
 
     // Verify database was updated with new values
-    let updated_size: usize = GetItem::get(
+    let updated_size: f64 = GetItem::get(
         item_store.as_ref(),
         &ctx,
         SEGKEY_LAYOUT_SIDEBAR.join("size"),
@@ -363,7 +362,7 @@ async fn update_state_overwrite_existing() {
     .unwrap()
     .deserialize()
     .unwrap();
-    assert_eq!(updated_size, 300);
+    assert_eq!(updated_size, 300.0);
 
     let updated_visible: bool = GetItem::get(
         item_store.as_ref(),


### PR DESCRIPTION
1. (Fixed in SAPIC-459) Allow workspace to be opened even if it contains invalid collections
2. Store the size of sidebar and panel as f64, consistent with `EditorGridState`, since the frontend will always pass a floating number as the size.
3. Previously, we will not create `expandedEntries` key in the collection state database if no entry's expand flag is updated. This will lead to false warning for subsequent `stream_collection_entries` operation. Now we will always create this key when creating and cloning a collection.