### PR TITLE
feat(SAPIC-484): Implementation of the collection select functionality

### DIFF
--- a/crates/moss-workspace/bindings/events.ts
+++ b/crates/moss-workspace/bindings/events.ts
@@ -24,6 +24,7 @@ export type StreamEnvironmentsEvent = {
    * If the environment is global, this will be `None`.
    */
   collectionId?: string;
+  isActive: boolean;
   name: string;
   order?: number;
   totalVariables: number;

--- a/crates/moss-workspace/bindings/events.zod.ts
+++ b/crates/moss-workspace/bindings/events.zod.ts
@@ -5,6 +5,7 @@ import { branchInfoSchema } from "./types.zod";
 export const streamEnvironmentsEventSchema = z.object({
   id: z.string(),
   collectionId: z.string().optional(),
+  isActive: z.boolean(),
   name: z.string(),
   order: z.number().optional(),
   totalVariables: z.number(),

--- a/crates/moss-workspace/bindings/operations.ts
+++ b/crates/moss-workspace/bindings/operations.ts
@@ -18,6 +18,10 @@ import type {
   VcsInfo,
 } from "./types";
 
+export type ActivateEnvironmentInput = { environmentId: string; groupId?: string };
+
+export type ActivateEnvironmentOutput = { environmentId: string };
+
 /**
  * @category Operation
  */

--- a/crates/moss-workspace/bindings/operations.zod.ts
+++ b/crates/moss-workspace/bindings/operations.zod.ts
@@ -19,6 +19,15 @@ import {
   vcsInfoSchema,
 } from "./types.zod";
 
+export const activateEnvironmentInputSchema = z.object({
+  environmentId: z.string(),
+  groupId: z.string().optional(),
+});
+
+export const activateEnvironmentOutputSchema = z.object({
+  environmentId: z.string(),
+});
+
 export const batchUpdateCollectionOutputSchema = z.object({
   ids: z.array(z.string()),
 });

--- a/crates/moss-workspace/src/api.rs
+++ b/crates/moss-workspace/src/api.rs
@@ -1,3 +1,4 @@
+pub mod activate_environment;
 pub mod batch_update_collection;
 pub mod batch_update_environment;
 pub mod batch_update_environment_group;

--- a/crates/moss-workspace/src/api/activate_environment.rs
+++ b/crates/moss-workspace/src/api/activate_environment.rs
@@ -1,0 +1,29 @@
+use moss_applib::AppRuntime;
+
+use crate::{
+    Workspace,
+    models::operations::{ActivateEnvironmentInput, ActivateEnvironmentOutput},
+    services::environment_service::ActivateEnvironmentItemParams,
+};
+
+impl<R: AppRuntime> Workspace<R> {
+    pub async fn activate_environment(
+        &self,
+        ctx: &R::AsyncContext,
+        input: ActivateEnvironmentInput,
+    ) -> joinerror::Result<ActivateEnvironmentOutput> {
+        self.environment_service
+            .activate_environment(
+                ctx,
+                ActivateEnvironmentItemParams {
+                    environment_id: input.environment_id.clone(),
+                    group_id: input.group_id,
+                },
+            )
+            .await?;
+
+        Ok(ActivateEnvironmentOutput {
+            environment_id: input.environment_id,
+        })
+    }
+}

--- a/crates/moss-workspace/src/api/stream_environments.rs
+++ b/crates/moss-workspace/src/api/stream_environments.rs
@@ -25,6 +25,7 @@ impl<R: AppRuntime> Workspace<R> {
             if let Err(e) = channel.send(StreamEnvironmentsEvent {
                 id: item.id,
                 collection_id: item.collection_id.map(|id| CollectionId::from(id)),
+                is_active: item.is_active,
                 name: item.display_name,
                 order: item.order,
                 total_variables: item.total_variables,

--- a/crates/moss-workspace/src/models/events.rs
+++ b/crates/moss-workspace/src/models/events.rs
@@ -35,6 +35,7 @@ pub struct StreamEnvironmentsEvent {
     /// The id of the collection that the environment belongs to.
     /// If the environment is global, this will be `None`.
     pub collection_id: Option<CollectionId>,
+    pub is_active: bool,
 
     pub name: String,
     pub order: Option<isize>,

--- a/crates/moss-workspace/src/models/operations.rs
+++ b/crates/moss-workspace/src/models/operations.rs
@@ -205,9 +205,25 @@ pub struct StreamCollectionsOutput {
 // ------------------------------ //
 // Environment
 // ------------------------------ //
+// Activate Environment
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(optional_fields)]
+#[ts(export, export_to = "operations.ts")]
+pub struct ActivateEnvironmentInput {
+    pub environment_id: EnvironmentId,
+    // FIXME: Should this be `collection_id` instead?
+    pub group_id: Option<CollectionId>,
+}
+
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export, export_to = "operations.ts")]
+pub struct ActivateEnvironmentOutput {
+    pub environment_id: EnvironmentId,
+}
 
 // Create Environment
-
 // FIXME: Should this be refactored to use an inner params?
 
 /// @category Operation

--- a/crates/moss-workspace/tests/workspace__activate_environment.rs
+++ b/crates/moss-workspace/tests/workspace__activate_environment.rs
@@ -1,0 +1,292 @@
+#![cfg(feature = "integration-tests")]
+
+use moss_applib::AppRuntime;
+use moss_environment::models::primitives::EnvironmentId;
+use moss_testutils::random_name::{random_collection_name, random_environment_name};
+use moss_workspace::{
+    Workspace,
+    models::{
+        events::StreamEnvironmentsEvent,
+        operations::{ActivateEnvironmentInput, CreateCollectionInput, CreateEnvironmentInput},
+        types::CreateCollectionParams,
+    },
+};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+use tauri::ipc::{Channel, InvokeResponseBody};
+
+use crate::shared::setup_test_workspace;
+
+pub mod shared;
+
+async fn test_stream_environments<R: AppRuntime>(
+    ctx: &R::AsyncContext,
+    workspace: &Workspace<R>,
+) -> HashMap<EnvironmentId, StreamEnvironmentsEvent> {
+    let received_events = Arc::new(Mutex::new(Vec::new()));
+    let received_events_clone = received_events.clone();
+
+    let channel = Channel::new(move |body: InvokeResponseBody| {
+        if let InvokeResponseBody::Json(json_str) = body {
+            if let Ok(event) = serde_json::from_str::<StreamEnvironmentsEvent>(&json_str) {
+                received_events_clone.lock().unwrap().push(event);
+            }
+        }
+        Ok(())
+    });
+
+    let _ = workspace.stream_environments(ctx, channel.clone()).await;
+    received_events
+        .lock()
+        .unwrap()
+        .iter()
+        .map(|event| (event.id.clone(), event.clone()))
+        .collect()
+}
+
+#[tokio::test]
+async fn activate_environment_global() {
+    let (ctx, workspace, cleanup) = setup_test_workspace().await;
+
+    let environment_name = random_environment_name();
+    let create_environment_output = workspace
+        .create_environment(
+            &ctx,
+            CreateEnvironmentInput {
+                name: environment_name,
+                collection_id: None,
+                order: 42,
+                color: None,
+                variables: vec![],
+            },
+        )
+        .await
+        .unwrap();
+
+    let id = create_environment_output.id;
+
+    let events_map = test_stream_environments(&ctx, &workspace).await;
+
+    // Newly created environments are not automatically activated
+    assert!(!events_map.get(&id).unwrap().is_active);
+    workspace
+        .activate_environment(
+            &ctx,
+            ActivateEnvironmentInput {
+                environment_id: id.clone(),
+                group_id: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let events_map = test_stream_environments(&ctx, &workspace).await;
+
+    assert!(events_map.get(&id).unwrap().is_active);
+
+    cleanup().await;
+}
+
+#[tokio::test]
+async fn activate_environment_collection() {
+    let (ctx, workspace, cleanup) = setup_test_workspace().await;
+
+    let collection_name = random_collection_name();
+    let collection_id = workspace
+        .create_collection(
+            &ctx,
+            &CreateCollectionInput {
+                inner: CreateCollectionParams {
+                    name: collection_name,
+                    order: 0,
+                    external_path: None,
+                    git_params: None,
+                    icon_path: None,
+                },
+            },
+        )
+        .await
+        .unwrap()
+        .id;
+
+    let environment_name = random_environment_name();
+    let create_environment_output = workspace
+        .create_environment(
+            &ctx,
+            CreateEnvironmentInput {
+                name: environment_name,
+                collection_id: Some(collection_id.clone()),
+                order: 42,
+                color: None,
+                variables: vec![],
+            },
+        )
+        .await
+        .unwrap();
+
+    let id = create_environment_output.id;
+
+    let events_map = test_stream_environments(&ctx, &workspace).await;
+
+    // Newly created environments are not automatically activated
+    assert!(!events_map.get(&id).unwrap().is_active);
+
+    workspace
+        .activate_environment(
+            &ctx,
+            ActivateEnvironmentInput {
+                environment_id: id.clone(),
+                group_id: Some(collection_id.clone()),
+            },
+        )
+        .await
+        .unwrap();
+
+    let events_map = test_stream_environments(&ctx, &workspace).await;
+
+    assert!(events_map.get(&id).unwrap().is_active);
+
+    cleanup().await;
+}
+
+#[tokio::test]
+async fn activate_environment_currently_active() {
+    let (ctx, workspace, cleanup) = setup_test_workspace().await;
+
+    let environment_name = random_environment_name();
+    let create_environment_output = workspace
+        .create_environment(
+            &ctx,
+            CreateEnvironmentInput {
+                name: environment_name,
+                collection_id: None,
+                order: 0,
+                color: None,
+                variables: vec![],
+            },
+        )
+        .await
+        .unwrap();
+
+    let id = create_environment_output.id;
+
+    workspace
+        .activate_environment(
+            &ctx,
+            ActivateEnvironmentInput {
+                environment_id: id.clone(),
+                group_id: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    // Try activating a currently active environment
+    workspace
+        .activate_environment(
+            &ctx,
+            ActivateEnvironmentInput {
+                environment_id: id.clone(),
+                group_id: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let events_map = test_stream_environments(&ctx, &workspace).await;
+
+    assert!(events_map.get(&id).unwrap().is_active);
+
+    cleanup().await;
+}
+
+// Activating environments for any group (including global) should not affect other groups
+#[tokio::test]
+async fn activate_environment_groups_isolation() {
+    let (ctx, workspace, cleanup) = setup_test_workspace().await;
+    let collection_name = random_collection_name();
+    let collection_id = workspace
+        .create_collection(
+            &ctx,
+            &CreateCollectionInput {
+                inner: CreateCollectionParams {
+                    name: collection_name,
+                    order: 0,
+                    external_path: None,
+                    git_params: None,
+                    icon_path: None,
+                },
+            },
+        )
+        .await
+        .unwrap()
+        .id;
+
+    let collection_env_name = random_environment_name();
+    let collection_env_id = workspace
+        .create_environment(
+            &ctx,
+            CreateEnvironmentInput {
+                collection_id: Some(collection_id.clone()),
+                name: collection_env_name,
+                order: 0,
+                color: None,
+                variables: vec![],
+            },
+        )
+        .await
+        .unwrap()
+        .id;
+
+    let global_env_name = random_environment_name();
+    let global_env_id = workspace
+        .create_environment(
+            &ctx,
+            CreateEnvironmentInput {
+                collection_id: None,
+                name: global_env_name,
+                order: 0,
+                color: None,
+                variables: vec![],
+            },
+        )
+        .await
+        .unwrap()
+        .id;
+
+    workspace
+        .activate_environment(
+            &ctx,
+            ActivateEnvironmentInput {
+                environment_id: global_env_id.clone(),
+                group_id: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let events_map = test_stream_environments(&ctx, &workspace).await;
+
+    assert!(events_map.get(&global_env_id).unwrap().is_active);
+    assert!(!events_map.get(&collection_env_id).unwrap().is_active);
+    cleanup().await;
+}
+
+#[tokio::test]
+async fn activate_environment_nonexistent() {
+    let (ctx, workspace, cleanup) = setup_test_workspace().await;
+    let result = workspace
+        .activate_environment(
+            &ctx,
+            ActivateEnvironmentInput {
+                environment_id: EnvironmentId::new(),
+                group_id: None,
+            },
+        )
+        .await;
+
+    assert!(result.is_err());
+    cleanup().await;
+}

--- a/view/desktop/bin/src/commands/workspace.rs
+++ b/view/desktop/bin/src/commands/workspace.rs
@@ -159,6 +159,21 @@ pub async fn batch_update_collection<'a, R: tauri::Runtime>(
 
 #[tauri::command(async)]
 #[instrument(level = "trace", skip(ctx, app), fields(window = window.label()))]
+pub async fn activate_environment<'a, R: tauri::Runtime>(
+    ctx: AsyncContext<'a>,
+    app: App<'a, R>,
+    window: Window<R>,
+    input: ActivateEnvironmentInput,
+    options: Options,
+) -> TauriResult<ActivateEnvironmentOutput> {
+    super::with_workspace_timeout(ctx.inner(), app, options, |ctx, workspace| async move {
+        workspace.activate_environment(&ctx, input).await
+    })
+    .await
+}
+
+#[tauri::command(async)]
+#[instrument(level = "trace", skip(ctx, app), fields(window = window.label()))]
 pub async fn create_environment<'a, R: tauri::Runtime>(
     ctx: AsyncContext<'a>,
     app: App<'a, R>,

--- a/view/desktop/bin/src/lib.rs
+++ b/view/desktop/bin/src/lib.rs
@@ -150,6 +150,7 @@ pub async fn run<R: TauriRuntime>() {
             commands::delete_collection,
             commands::update_collection,
             commands::batch_update_collection,
+            commands::activate_environment,
             commands::create_environment,
             commands::update_environment,
             commands::stream_environments,


### PR DESCRIPTION
Introduce `Workspace::activate_environment`, which allows changing the currently active environment for each environment group (including the global group). 

Each environment group can have at most one active environment, and changing the active environment for one group does not affect the others. When streaming environments, each environment event has a field `is_active` indicating whether it is currently activated

By default, a newly created environment will not be automatically activated. 