### PR TITLE
refactor(SAPIC-496): Restructuring the collection manifest file

### DIFF
--- a/.idea/sapic.iml
+++ b/.idea/sapic.iml
@@ -52,6 +52,8 @@
       <sourceFolder url="file://$MODULE_DIR$/crates/moss-logging/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/crates/moss-git/tests" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/crates/moss-id-macro/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/moss-activity-broadcaster/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/libs/joinerror/macros/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/crates/moss-edit/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/crates/moss-edit/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/crates/moss-workspacelib/src" isTestSource="false" />

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3580,6 +3580,7 @@ dependencies = [
  "moss_hcl",
  "moss_id_macro",
  "moss_keyring",
+ "moss_logging",
  "moss_storage",
  "moss_testutils",
  "moss_text",
@@ -3591,6 +3592,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tokio",
+ "tracing",
  "ts-rs",
  "validator",
 ]

--- a/crates/moss-collection/Cargo.toml
+++ b/crates/moss-collection/Cargo.toml
@@ -20,6 +20,7 @@ moss_bindingutils.workspace = true
 moss_applib.workspace = true
 moss_keyring.workspace = true
 moss_id_macro.workspace = true
+moss_logging.workspace = true
 
 joinerror.workspace = true
 anyhow.workspace = true
@@ -40,6 +41,7 @@ reqwest = { workspace = true, optional = true }
 rustc-hash.workspace = true
 oauth2 = { workspace = true, features = ["ureq"], optional = true }
 chrono.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 tauri = { workspace = true, features = ["test"] }

--- a/crates/moss-collection/src/builder.rs
+++ b/crates/moss-collection/src/builder.rs
@@ -149,7 +149,7 @@ impl<R: AppRuntime> CollectionBuilder<R> {
 
         let repo_handle = if params.internal_abs_path.join(".git").exists() {
             self.load_repo_handle(
-                manifest.vcs.map(|vcs| vcs.git_provider_type()),
+                manifest.vcs.map(|vcs| vcs.provider()),
                 params.internal_abs_path.clone(),
             )
             .await
@@ -243,10 +243,10 @@ impl<R: AppRuntime> CollectionBuilder<R> {
         let vcs = params.git_params.as_ref().and_then(|p| {
             match normalize_git_url(&p.repository) {
                 Ok(normalized_repository) => match p.git_provider_type {
-                    GitProviderType::GitHub => Some(ManifestVcs::GITHUB {
+                    GitProviderType::GitHub => Some(ManifestVcs::GitHub {
                         repository: normalized_repository,
                     }),
-                    GitProviderType::GitLab => Some(ManifestVcs::GITLAB {
+                    GitProviderType::GitLab => Some(ManifestVcs::GitLab {
                         repository: normalized_repository,
                     }),
                 },

--- a/crates/moss-collection/src/collection.rs
+++ b/crates/moss-collection/src/collection.rs
@@ -157,7 +157,7 @@ impl<R: AppRuntime> Collection<R> {
             }
         };
 
-        let git_provider_type = vcs.git_provider_type();
+        let git_provider_type = vcs.provider();
         let client: Arc<dyn GitHostingProvider> = match &git_provider_type {
             GitProviderType::GitHub => self.github_client.clone(),
             GitProviderType::GitLab => self.gitlab_client.clone(),
@@ -239,33 +239,6 @@ impl<R: AppRuntime> Collection<R> {
         }
 
         // TODO: Reintroduce repository updating
-        // match params.repository {
-        //     Some(ChangeString::Update(url)) => {
-        //         let normalized_url = normalize_git_url(&url)?;
-        //         patches.push((
-        //             PatchOperation::Add(AddOperation {
-        //                 path: unsafe { PointerBuf::new_unchecked("/repository/url") },
-        //                 value: JsonValue::String(normalized_url),
-        //             }),
-        //             EditOptions {
-        //                 create_missing_segments: false,
-        //                 ignore_if_not_exists: false,
-        //             },
-        //         ));
-        //     }
-        //     Some(ChangeString::Remove) => {
-        //         patches.push((
-        //             PatchOperation::Remove(RemoveOperation {
-        //                 path: unsafe { PointerBuf::new_unchecked("/repository/url") },
-        //             }),
-        //             EditOptions {
-        //                 create_missing_segments: false,
-        //                 ignore_if_not_exists: true,
-        //             },
-        //         ));
-        //     }
-        //     None => {}
-        // }
 
         match params.icon_path {
             None => {}

--- a/crates/moss-collection/src/collection.rs
+++ b/crates/moss-collection/src/collection.rs
@@ -1,8 +1,6 @@
 use chrono::{DateTime, Utc};
 use joinerror::ResultExt;
-use json_patch::{
-    AddOperation, PatchOperation, RemoveOperation, ReplaceOperation, jsonptr::PointerBuf,
-};
+use json_patch::{PatchOperation, ReplaceOperation, jsonptr::PointerBuf};
 use moss_applib::{
     AppRuntime, EventMarker,
     subscription::{Event, EventEmitter},
@@ -10,7 +8,7 @@ use moss_applib::{
 use moss_bindingutils::primitives::{ChangePath, ChangeString};
 use moss_edit::json::EditOptions;
 use moss_fs::{FileSystem, FsResultExt};
-use moss_git::{models::types::BranchInfo, url::normalize_git_url};
+use moss_git::models::types::BranchInfo;
 use moss_git_hosting_provider::{
     GitHostingProvider,
     common::GitUrl,
@@ -146,19 +144,20 @@ impl<R: AppRuntime> Collection<R> {
             created_at: created_at.to_rfc3339(),
         };
 
-        let Some(repo_desc) = manifest.repository else {
+        let Some(vcs) = manifest.vcs else {
             return Ok(output);
         };
 
-        let repo_ref = match GitUrl::parse(&repo_desc.url) {
+        let repository = vcs.repository();
+        let repo_ref = match GitUrl::parse(repository) {
             Ok(repo_ref) => repo_ref,
             Err(e) => {
-                println!("unable to parse repository url{}: {}", repo_desc.url, e);
+                println!("unable to parse repository url{}: {}", repository, e);
                 return Ok(output);
             }
         };
 
-        let git_provider_type = repo_desc.git_provider_type;
+        let git_provider_type = vcs.git_provider_type();
         let client: Arc<dyn GitHostingProvider> = match &git_provider_type {
             GitProviderType::GitHub => self.github_client.clone(),
             GitProviderType::GitLab => self.gitlab_client.clone(),
@@ -239,33 +238,34 @@ impl<R: AppRuntime> Collection<R> {
             ));
         }
 
-        match params.repository {
-            Some(ChangeString::Update(url)) => {
-                let normalized_url = normalize_git_url(&url)?;
-                patches.push((
-                    PatchOperation::Add(AddOperation {
-                        path: unsafe { PointerBuf::new_unchecked("/repository/url") },
-                        value: JsonValue::String(normalized_url),
-                    }),
-                    EditOptions {
-                        create_missing_segments: false,
-                        ignore_if_not_exists: false,
-                    },
-                ));
-            }
-            Some(ChangeString::Remove) => {
-                patches.push((
-                    PatchOperation::Remove(RemoveOperation {
-                        path: unsafe { PointerBuf::new_unchecked("/repository/url") },
-                    }),
-                    EditOptions {
-                        create_missing_segments: false,
-                        ignore_if_not_exists: true,
-                    },
-                ));
-            }
-            None => {}
-        }
+        // TODO: Reintroduce repository updating
+        // match params.repository {
+        //     Some(ChangeString::Update(url)) => {
+        //         let normalized_url = normalize_git_url(&url)?;
+        //         patches.push((
+        //             PatchOperation::Add(AddOperation {
+        //                 path: unsafe { PointerBuf::new_unchecked("/repository/url") },
+        //                 value: JsonValue::String(normalized_url),
+        //             }),
+        //             EditOptions {
+        //                 create_missing_segments: false,
+        //                 ignore_if_not_exists: false,
+        //             },
+        //         ));
+        //     }
+        //     Some(ChangeString::Remove) => {
+        //         patches.push((
+        //             PatchOperation::Remove(RemoveOperation {
+        //                 path: unsafe { PointerBuf::new_unchecked("/repository/url") },
+        //             }),
+        //             EditOptions {
+        //                 create_missing_segments: false,
+        //                 ignore_if_not_exists: true,
+        //             },
+        //         ));
+        //     }
+        //     None => {}
+        // }
 
         match params.icon_path {
             None => {}

--- a/crates/moss-collection/src/manifest.rs
+++ b/crates/moss-collection/src/manifest.rs
@@ -6,11 +6,28 @@ pub(crate) const MANIFEST_FILE_NAME: &str = "Sapic.json";
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(super) struct ManifestFile {
     pub name: String,
-    pub repository: Option<ManifestRepository>,
+    pub vcs: Option<ManifestVcs>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(super) struct ManifestRepository {
-    pub url: String,
-    pub git_provider_type: GitProviderType,
+#[serde(rename_all = "lowercase")]
+pub(super) enum ManifestVcs {
+    GITHUB { repository: String },
+    GITLAB { repository: String },
+}
+
+impl ManifestVcs {
+    pub fn git_provider_type(&self) -> GitProviderType {
+        match self {
+            ManifestVcs::GITHUB { .. } => GitProviderType::GitHub,
+            ManifestVcs::GITLAB { .. } => GitProviderType::GitLab,
+        }
+    }
+
+    pub fn repository(&self) -> &str {
+        match self {
+            ManifestVcs::GITHUB { repository, .. } => repository,
+            ManifestVcs::GITLAB { repository, .. } => repository,
+        }
+    }
 }

--- a/crates/moss-collection/src/manifest.rs
+++ b/crates/moss-collection/src/manifest.rs
@@ -12,22 +12,22 @@ pub(super) struct ManifestFile {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub(super) enum ManifestVcs {
-    GITHUB { repository: String },
-    GITLAB { repository: String },
+    GitHub { repository: String },
+    GitLab { repository: String },
 }
 
 impl ManifestVcs {
-    pub fn git_provider_type(&self) -> GitProviderType {
+    pub fn provider(&self) -> GitProviderType {
         match self {
-            ManifestVcs::GITHUB { .. } => GitProviderType::GitHub,
-            ManifestVcs::GITLAB { .. } => GitProviderType::GitLab,
+            ManifestVcs::GitHub { .. } => GitProviderType::GitHub,
+            ManifestVcs::GitLab { .. } => GitProviderType::GitLab,
         }
     }
 
     pub fn repository(&self) -> &str {
         match self {
-            ManifestVcs::GITHUB { repository, .. } => repository,
-            ManifestVcs::GITLAB { repository, .. } => repository,
+            ManifestVcs::GitHub { repository, .. } => repository,
+            ManifestVcs::GitLab { repository, .. } => repository,
         }
     }
 }

--- a/crates/moss-workspace/src/api/stream_collections.rs
+++ b/crates/moss-workspace/src/api/stream_collections.rs
@@ -18,6 +18,10 @@ impl<R: AppRuntime> Workspace<R> {
         tokio::pin!(stream);
 
         let mut total_returned = 0;
+
+        // OPTIMIZE: Right now `stream_collections` need to do provider API calls, which is slow
+        // We should consider streaming vcs summary from a different channel
+
         while let Some(desc) = stream.next().await {
             let event = StreamCollectionsEvent {
                 id: desc.id,


### PR DESCRIPTION
The new collection manifest looks like this:
```
{
    "name": "My Collection",
    "vcs": {
        "github": {
            "repository": "github.com/user/collection",
        }
    }
}
```

Disable the updating of collection repo url until we implement relinking a collection with a different repository. The old collections will no longer be recognized after this refactor.