### PR TITLE
feat(SAPIC-498): Implementation of collection archiving feature

### DIFF
--- a/crates/moss-collection/src/api/common.rs
+++ b/crates/moss-collection/src/api/common.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use joinerror::Error;
 use moss_applib::{AppRuntime, errors::ValidationResultExt};
 use moss_hcl::Block;
 use validator::Validate;
@@ -32,6 +33,8 @@ impl<R: AppRuntime> Collection<R> {
         let model = EntryModel::from((id.clone(), class_from_path(&input.path)));
 
         self.worktree
+            .get()
+            .ok_or(Error::new::<()>("worktree is not loaded yet"))?
             .create_dir_entry(
                 ctx,
                 &input.name,
@@ -102,6 +105,8 @@ impl<R: AppRuntime> Collection<R> {
         };
 
         self.worktree
+            .get()
+            .ok_or(Error::new::<()>("worktree is not loaded yet"))?
             .create_item_entry(ctx, &input.name, &input.path, model, input.order, false)
             .await?;
 
@@ -117,6 +122,8 @@ impl<R: AppRuntime> Collection<R> {
 
         let path = self
             .worktree
+            .get()
+            .ok_or(Error::new::<()>("worktree is not loaded yet"))?
             .update_item_entry(
                 ctx,
                 &input.id,
@@ -156,6 +163,8 @@ impl<R: AppRuntime> Collection<R> {
 
         let path = self
             .worktree
+            .get()
+            .ok_or(Error::new::<()>("worktree is not loaded yet"))?
             .update_dir_entry(
                 ctx,
                 &input.id,

--- a/crates/moss-collection/src/api/common.rs
+++ b/crates/moss-collection/src/api/common.rs
@@ -1,8 +1,6 @@
-use std::path::Path;
-
-use joinerror::Error;
 use moss_applib::{AppRuntime, errors::ValidationResultExt};
 use moss_hcl::Block;
+use std::path::Path;
 use validator::Validate;
 
 use crate::{
@@ -32,9 +30,8 @@ impl<R: AppRuntime> Collection<R> {
         let id = EntryId::new();
         let model = EntryModel::from((id.clone(), class_from_path(&input.path)));
 
-        self.worktree
-            .get()
-            .ok_or(Error::new::<()>("worktree is not loaded yet"))?
+        self.worktree()
+            .await
             .create_dir_entry(
                 ctx,
                 &input.name,
@@ -104,9 +101,8 @@ impl<R: AppRuntime> Collection<R> {
             }
         };
 
-        self.worktree
-            .get()
-            .ok_or(Error::new::<()>("worktree is not loaded yet"))?
+        self.worktree()
+            .await
             .create_item_entry(ctx, &input.name, &input.path, model, input.order, false)
             .await?;
 
@@ -121,9 +117,8 @@ impl<R: AppRuntime> Collection<R> {
         input.validate().join_err_bare()?;
 
         let path = self
-            .worktree
-            .get()
-            .ok_or(Error::new::<()>("worktree is not loaded yet"))?
+            .worktree()
+            .await
             .update_item_entry(
                 ctx,
                 &input.id,
@@ -162,9 +157,8 @@ impl<R: AppRuntime> Collection<R> {
         input.validate().join_err_bare()?;
 
         let path = self
-            .worktree
-            .get()
-            .ok_or(Error::new::<()>("worktree is not loaded yet"))?
+            .worktree()
+            .await
             .update_dir_entry(
                 ctx,
                 &input.id,

--- a/crates/moss-collection/src/api/delete_entry.rs
+++ b/crates/moss-collection/src/api/delete_entry.rs
@@ -1,4 +1,3 @@
-use joinerror::Error;
 use moss_applib::{AppRuntime, errors::ValidationResultExt};
 use validator::Validate;
 
@@ -14,11 +13,7 @@ impl<R: AppRuntime> Collection<R> {
         input: DeleteEntryInput,
     ) -> joinerror::Result<DeleteEntryOutput> {
         input.validate().join_err_bare()?;
-        self.worktree
-            .get()
-            .ok_or(Error::new::<()>("worktree is not loaded yet"))?
-            .remove_entry(ctx, &input.id)
-            .await?;
+        self.worktree().await.remove_entry(ctx, &input.id).await?;
 
         Ok(DeleteEntryOutput { id: input.id })
     }

--- a/crates/moss-collection/src/api/delete_entry.rs
+++ b/crates/moss-collection/src/api/delete_entry.rs
@@ -1,3 +1,4 @@
+use joinerror::Error;
 use moss_applib::{AppRuntime, errors::ValidationResultExt};
 use validator::Validate;
 
@@ -13,7 +14,11 @@ impl<R: AppRuntime> Collection<R> {
         input: DeleteEntryInput,
     ) -> joinerror::Result<DeleteEntryOutput> {
         input.validate().join_err_bare()?;
-        self.worktree.remove_entry(ctx, &input.id).await?;
+        self.worktree
+            .get()
+            .ok_or(Error::new::<()>("worktree is not loaded yet"))?
+            .remove_entry(ctx, &input.id)
+            .await?;
 
         Ok(DeleteEntryOutput { id: input.id })
     }

--- a/crates/moss-collection/src/api/stream_entries.rs
+++ b/crates/moss-collection/src/api/stream_entries.rs
@@ -21,7 +21,7 @@ use crate::{
         operations::{StreamEntriesInput, StreamEntriesOutput},
         primitives::{EntryId, FrontendEntryPath},
     },
-    worktree::{Worktree, entry::EntryDescription},
+    worktree::entry::EntryDescription,
 };
 
 const EXPANSION_DIRECTORIES: &[&str] = &[
@@ -70,18 +70,7 @@ impl<R: AppRuntime> Collection<R> {
 
         for dir in expansion_dirs {
             let entries_tx_clone = tx.clone();
-            let worktree_service_clone = self
-                .worktree
-                .get_or_init(|| async {
-                    Arc::new(Worktree::new(
-                        self.abs_path.clone(),
-                        self.fs.clone(),
-                        self.broadcaster.clone(),
-                        self.storage_service.clone(),
-                    ))
-                })
-                .await
-                .to_owned();
+            let worktree_service_clone = self.worktree().await.to_owned();
             // We need to fetch this data from the database here, otherwise we'll be requesting it every time the scan method is called.
 
             let handle = tokio::spawn({

--- a/crates/moss-collection/src/builder.rs
+++ b/crates/moss-collection/src/builder.rs
@@ -1,7 +1,7 @@
 use joinerror::ResultExt;
 use moss_activity_broadcaster::ActivityBroadcaster;
 use moss_applib::{AppRuntime, subscription::EventEmitter};
-use moss_fs::{CreateOptions, FileSystem};
+use moss_fs::{CreateOptions, FileSystem, FsResultExt};
 use moss_git::{repository::Repository, url::GitUrl};
 use moss_git_hosting_provider::GitProviderKind;
 use moss_logging::session;

--- a/crates/moss-collection/src/collection.rs
+++ b/crates/moss-collection/src/collection.rs
@@ -85,6 +85,19 @@ impl<R: AppRuntime> Collection<R> {
 }
 
 impl<R: AppRuntime> Collection<R> {
+    pub(crate) async fn worktree(&self) -> &Arc<Worktree<R>> {
+        self.worktree
+            .get_or_init(|| async {
+                Arc::new(Worktree::new(
+                    self.abs_path.clone(),
+                    self.fs.clone(),
+                    self.broadcaster.clone(),
+                    self.storage_service.clone(),
+                ))
+            })
+            .await
+    }
+
     pub fn is_archived(&self) -> bool {
         self.archived.load(Ordering::SeqCst)
     }

--- a/crates/moss-collection/src/collection.rs
+++ b/crates/moss-collection/src/collection.rs
@@ -11,6 +11,7 @@ use moss_bindingutils::primitives::{ChangePath, ChangeString};
 use moss_edit::json::EditOptions;
 use moss_fs::{CreateOptions, FileSystem, FsResultExt};
 use moss_git::{repository::Repository, url::GitUrl};
+use moss_git_hosting_provider::GitProviderKind;
 use moss_user::models::primitives::AccountId;
 use serde_json::Value as JsonValue;
 use std::{
@@ -57,16 +58,22 @@ pub struct CollectionDetails {
     pub vcs: Option<VcsDetails>,
 }
 
-pub enum VcsDetails {
-    GitHub { repository: String },
-    GitLab { repository: String },
+pub struct VcsDetails {
+    pub kind: GitProviderKind,
+    pub repository: String,
 }
 
 impl From<ManifestVcs> for VcsDetails {
     fn from(value: ManifestVcs) -> Self {
         match value {
-            ManifestVcs::GitHub { repository } => VcsDetails::GitHub { repository },
-            ManifestVcs::GitLab { repository } => VcsDetails::GitLab { repository },
+            ManifestVcs::GitHub { repository } => Self {
+                kind: GitProviderKind::GitHub,
+                repository,
+            },
+            ManifestVcs::GitLab { repository } => Self {
+                kind: GitProviderKind::GitLab,
+                repository,
+            },
         }
     }
 }

--- a/crates/moss-collection/src/config.rs
+++ b/crates/moss-collection/src/config.rs
@@ -1,3 +1,4 @@
+use moss_user::models::primitives::AccountId;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -8,4 +9,6 @@ pub struct ConfigFile {
     pub archived: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub external_path: Option<PathBuf>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account_id: Option<AccountId>,
 }

--- a/crates/moss-collection/src/config.rs
+++ b/crates/moss-collection/src/config.rs
@@ -5,6 +5,7 @@ pub const CONFIG_FILE_NAME: &str = "config.json";
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ConfigFile {
+    pub archived: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub external_path: Option<PathBuf>,
 }

--- a/crates/moss-collection/src/worktree.rs
+++ b/crates/moss-collection/src/worktree.rs
@@ -17,6 +17,7 @@ use serde_json::Value as JsonValue;
 use std::{
     cell::LazyCell,
     collections::{HashMap, HashSet},
+    fmt::Debug,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -86,6 +87,15 @@ pub(crate) struct Worktree<R: AppRuntime> {
     storage: Arc<StorageService<R>>,
     broadcaster: ActivityBroadcaster<R::EventLoop>,
     state: Arc<RwLock<WorktreeState>>,
+}
+
+// Required for OnceCell::set
+impl<R: AppRuntime> Debug for Worktree<R> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Worktree")
+            .field("abs_path", &self.abs_path)
+            .finish()
+    }
 }
 
 impl<R: AppRuntime> Worktree<R> {

--- a/crates/moss-workspace/bindings/events.ts
+++ b/crates/moss-workspace/bindings/events.ts
@@ -11,6 +11,7 @@ export type StreamCollectionsEvent = {
   expanded: boolean;
   branch?: BranchInfo;
   iconPath?: string;
+  archived: boolean;
 };
 
 /**

--- a/crates/moss-workspace/bindings/events.zod.ts
+++ b/crates/moss-workspace/bindings/events.zod.ts
@@ -17,4 +17,5 @@ export const streamCollectionsEventSchema = z.object({
   expanded: z.boolean(),
   branch: branchInfoSchema.optional(),
   iconPath: z.string().optional(),
+  archived: z.boolean(),
 });

--- a/crates/moss-workspace/bindings/operations.ts
+++ b/crates/moss-workspace/bindings/operations.ts
@@ -25,6 +25,16 @@ export type ActivateEnvironmentOutput = { environmentId: string };
 /**
  * @category Operation
  */
+export type ArchiveCollectionInput = { id: string };
+
+/**
+ * @category Operation
+ */
+export type ArchiveCollectionOutput = { id: string };
+
+/**
+ * @category Operation
+ */
 export type BatchUpdateCollectionInput = { items: Array<UpdateCollectionParams> };
 
 /**
@@ -165,6 +175,16 @@ export type StreamCollectionsOutput = {};
  * @category Operation
  */
 export type StreamEnvironmentsOutput = { groups: Array<EnvironmentGroup> };
+
+/**
+ * @category Operation
+ */
+export type UnarchiveCollectionInput = { id: string };
+
+/**
+ * @category Operation
+ */
+export type UnarchiveCollectionOutput = { id: string };
 
 /**
  * @category Operation

--- a/crates/moss-workspace/bindings/operations.zod.ts
+++ b/crates/moss-workspace/bindings/operations.zod.ts
@@ -28,6 +28,14 @@ export const activateEnvironmentOutputSchema = z.object({
   environmentId: z.string(),
 });
 
+export const archiveCollectionInputSchema = z.object({
+  id: z.string(),
+});
+
+export const archiveCollectionOutputSchema = z.object({
+  id: z.string(),
+});
+
 export const batchUpdateCollectionOutputSchema = z.object({
   ids: z.array(z.string()),
 });
@@ -85,6 +93,14 @@ export const importCollectionOutputSchema = z.object({
 });
 
 export const streamCollectionsOutputSchema = z.object({});
+
+export const unarchiveCollectionInputSchema = z.object({
+  id: z.string(),
+});
+
+export const unarchiveCollectionOutputSchema = z.object({
+  id: z.string(),
+});
 
 export const updateCollectionOutputSchema = z.object({
   id: z.string(),

--- a/crates/moss-workspace/src/api.rs
+++ b/crates/moss-workspace/src/api.rs
@@ -1,4 +1,5 @@
 pub mod activate_environment;
+pub mod archive_collection;
 pub mod batch_update_collection;
 pub mod batch_update_environment;
 pub mod batch_update_environment_group;
@@ -11,6 +12,7 @@ pub mod describe_state;
 pub mod import_collection;
 pub mod stream_collections;
 pub mod stream_environments;
+pub mod unarchive_collection;
 pub mod update_collection;
 pub mod update_environment;
 pub mod update_environment_group;

--- a/crates/moss-workspace/src/api/archive_collection.rs
+++ b/crates/moss-workspace/src/api/archive_collection.rs
@@ -1,0 +1,20 @@
+use moss_applib::AppRuntime;
+
+use crate::{
+    Workspace,
+    models::operations::{ArchiveCollectionInput, ArchiveCollectionOutput},
+};
+
+impl<R: AppRuntime> Workspace<R> {
+    pub async fn archive_collection(
+        &self,
+        ctx: &R::AsyncContext,
+        input: ArchiveCollectionInput,
+    ) -> joinerror::Result<ArchiveCollectionOutput> {
+        self.collection_service
+            .archive_collection(ctx, &input.id)
+            .await?;
+
+        Ok(ArchiveCollectionOutput { id: input.id })
+    }
+}

--- a/crates/moss-workspace/src/api/stream_collections.rs
+++ b/crates/moss-workspace/src/api/stream_collections.rs
@@ -34,6 +34,7 @@ impl<R: AppRuntime> Workspace<R> {
                 expanded: desc.expanded,
                 branch: desc.vcs.map(|vcs| vcs.branch),
                 icon_path: desc.icon_path,
+                archived: desc.archived,
             };
 
             if let Err(e) = channel.send(event) {

--- a/crates/moss-workspace/src/api/stream_collections.rs
+++ b/crates/moss-workspace/src/api/stream_collections.rs
@@ -37,6 +37,8 @@ impl<R: AppRuntime> Workspace<R> {
                 archived: desc.archived,
             };
 
+            dbg!(&event);
+
             if let Err(e) = channel.send(event) {
                 session::error!(format!(
                     "failed to send collection event through tauri channel: {}",

--- a/crates/moss-workspace/src/api/stream_collections.rs
+++ b/crates/moss-workspace/src/api/stream_collections.rs
@@ -37,8 +37,6 @@ impl<R: AppRuntime> Workspace<R> {
                 archived: desc.archived,
             };
 
-            dbg!(&event);
-
             if let Err(e) = channel.send(event) {
                 session::error!(format!(
                     "failed to send collection event through tauri channel: {}",

--- a/crates/moss-workspace/src/api/unarchive_collection.rs
+++ b/crates/moss-workspace/src/api/unarchive_collection.rs
@@ -1,0 +1,20 @@
+use moss_applib::AppRuntime;
+
+use crate::{
+    Workspace,
+    models::operations::{UnarchiveCollectionInput, UnarchiveCollectionOutput},
+};
+
+impl<R: AppRuntime> Workspace<R> {
+    pub async fn unarchive_collection(
+        &self,
+        ctx: &R::AsyncContext,
+        input: UnarchiveCollectionInput,
+    ) -> joinerror::Result<UnarchiveCollectionOutput> {
+        self.collection_service
+            .unarchive_collection(ctx, &input.id)
+            .await?;
+
+        Ok(UnarchiveCollectionOutput { id: input.id })
+    }
+}

--- a/crates/moss-workspace/src/models/events.rs
+++ b/crates/moss-workspace/src/models/events.rs
@@ -18,8 +18,8 @@ pub struct StreamCollectionsEvent {
     pub order: Option<isize>,
     pub expanded: bool,
     pub branch: Option<BranchInfo>,
-
     pub icon_path: Option<PathBuf>,
+    pub archived: bool,
 }
 
 /// @category Event

--- a/crates/moss-workspace/src/models/operations.rs
+++ b/crates/moss-workspace/src/models/operations.rs
@@ -140,6 +140,42 @@ pub struct DeleteCollectionOutput {
 }
 
 /// @category Operation
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export, export_to = "operations.ts")]
+pub struct ArchiveCollectionInput {
+    #[ts(type = "string")]
+    pub id: CollectionId,
+}
+
+/// @category Operation
+#[derive(Debug, Serialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export, export_to = "operations.ts")]
+pub struct ArchiveCollectionOutput {
+    #[ts(type = "string")]
+    pub id: CollectionId,
+}
+
+/// @category Operation
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export, export_to = "operations.ts")]
+pub struct UnarchiveCollectionInput {
+    #[ts(type = "string")]
+    pub id: CollectionId,
+}
+
+/// @category Operation
+#[derive(Debug, Serialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export, export_to = "operations.ts")]
+pub struct UnarchiveCollectionOutput {
+    #[ts(type = "string")]
+    pub id: CollectionId,
+}
+
+/// @category Operation
 #[derive(Debug, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export, export_to = "operations.ts")]

--- a/crates/moss-workspace/src/services/collection_service.rs
+++ b/crates/moss-workspace/src/services/collection_service.rs
@@ -693,10 +693,9 @@ async fn restore_collections<R: AppRuntime>(
 
         // Only load the vcs if the collection is not archived
         if !collection.is_archived() {
-            let vcs = collection.details().await?.vcs;
-            let account_id = collection.config().await?.account_id;
+            let details = collection.details().await?;
 
-            if let (Some(vcs), Some(account_id)) = (vcs, account_id) {
+            if let (Some(vcs), Some(account_id)) = (details.vcs, details.account_id) {
                 let account = active_profile
                     .account(&account_id)
                     .await

--- a/crates/moss-workspace/src/services/collection_service.rs
+++ b/crates/moss-workspace/src/services/collection_service.rs
@@ -231,7 +231,6 @@ impl<R: AppRuntime> CollectionService<R> {
         };
 
         if let (Some(git_params), Some(account)) = (git_params, account) {
-            let account_id = account.id();
             let client = match git_params.git_provider_type {
                 GitProviderKind::GitHub => GitClient::GitHub {
                     account: account,
@@ -246,13 +245,6 @@ impl<R: AppRuntime> CollectionService<R> {
             collection
                 .init_vcs(client, git_params.repository, git_params.branch)
                 .await?;
-
-            // FIXME: Not sure this is the best place to put this code
-            // However it will result in git2 type errorswhen placed inside `init_vcs()`
-            // Update account_id in config
-            let mut config = collection.config().await?;
-            config.account_id = Some(account_id);
-            collection.set_config(config).await?;
         }
 
         let icon_path = collection.icon_path();

--- a/crates/moss-workspace/src/services/collection_service.rs
+++ b/crates/moss-workspace/src/services/collection_service.rs
@@ -9,7 +9,6 @@ use moss_collection::{
         CollectionCloneParams, CollectionCreateGitParams, CollectionCreateParams,
         CollectionLoadParams,
     },
-    collection::VcsDetails,
     git::GitClient,
     vcs::VcsSummary,
 };
@@ -708,16 +707,17 @@ async fn restore_collections<R: AppRuntime>(
                         )
                     })?;
 
-                let client = match vcs {
-                    VcsDetails::GitHub { .. } => GitClient::GitHub {
+                let client = match vcs.kind {
+                    GitProviderKind::GitHub => GitClient::GitHub {
                         account,
                         api: GitHubApiClient::new(HttpClient::new()),
                     },
-                    VcsDetails::GitLab { .. } => GitClient::GitLab {
+                    GitProviderKind::GitLab => GitClient::GitLab {
                         account,
                         api: GitLabApiClient::new(HttpClient::new()),
                     },
                 };
+
                 collection.load_vcs(client).await?;
             }
         }

--- a/crates/moss-workspace/tests/shared/mod.rs
+++ b/crates/moss-workspace/tests/shared/mod.rs
@@ -3,7 +3,7 @@
 use image::{ImageBuffer, Rgb};
 use moss_activity_broadcaster::ActivityBroadcaster;
 use moss_applib::{
-    AppHandle,
+    AppHandle, AppRuntime,
     context::{AnyContext, AsyncContext, MutableContext},
     mock::MockAppRuntime,
 };
@@ -19,7 +19,9 @@ use moss_workspace::{
     Workspace,
     builder::{CreateWorkspaceParams, WorkspaceBuilder},
     models::{
-        primitives::{EditorGridOrientation, PanelRenderer},
+        events::StreamCollectionsEvent,
+        operations::StreamCollectionsOutput,
+        primitives::{CollectionId, EditorGridOrientation, PanelRenderer},
         types::{
             EditorGridLeafData, EditorGridNode, EditorGridState, EditorPanelState,
             EditorPartStateInfo,
@@ -34,10 +36,13 @@ use std::{
     future::Future,
     path::{Path, PathBuf},
     pin::Pin,
-    sync::Arc,
+    sync::{Arc, Mutex},
     time::Duration,
 };
-use tauri::Manager;
+use tauri::{
+    Manager,
+    ipc::{Channel, InvokeResponseBody},
+};
 
 pub type CleanupFn = Box<dyn FnOnce() -> Pin<Box<dyn Future<Output = ()> + Send>> + Send>;
 
@@ -217,4 +222,39 @@ pub fn generate_random_icon(output_path: &Path) {
     }
 
     img.save(output_path).unwrap();
+}
+
+#[allow(unused)]
+pub async fn test_stream_collections<R: AppRuntime>(
+    ctx: &R::AsyncContext,
+    workspace: &Workspace<R>,
+) -> (
+    HashMap<CollectionId, StreamCollectionsEvent>,
+    StreamCollectionsOutput,
+) {
+    let received_events = Arc::new(Mutex::new(Vec::new()));
+    let received_events_clone = received_events.clone();
+
+    let channel = Channel::new(move |body: InvokeResponseBody| {
+        if let InvokeResponseBody::Json(json_str) = body {
+            if let Ok(event) = serde_json::from_str::<StreamCollectionsEvent>(&json_str) {
+                received_events_clone.lock().unwrap().push(event);
+            }
+        }
+        Ok(())
+    });
+
+    let output = workspace
+        .stream_collections(ctx, channel.clone())
+        .await
+        .unwrap();
+    (
+        received_events
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|event| (event.id.clone(), event.clone()))
+            .collect(),
+        output,
+    )
 }

--- a/crates/moss-workspace/tests/workspace__archive_collection.rs
+++ b/crates/moss-workspace/tests/workspace__archive_collection.rs
@@ -1,0 +1,111 @@
+#![cfg(feature = "integration-tests")]
+
+use moss_testutils::random_name::random_collection_name;
+use moss_workspace::models::{
+    operations::{ArchiveCollectionInput, CreateCollectionInput},
+    primitives::CollectionId,
+    types::CreateCollectionParams,
+};
+
+use crate::shared::{setup_test_workspace, test_stream_collections};
+
+pub mod shared;
+
+#[tokio::test]
+pub async fn archive_collection_success() {
+    let (ctx, _, workspace, cleanup) = setup_test_workspace().await;
+
+    let collection_name = random_collection_name();
+    let id = workspace
+        .create_collection(
+            &ctx,
+            &CreateCollectionInput {
+                inner: CreateCollectionParams {
+                    name: collection_name.clone(),
+                    order: 0,
+                    external_path: None,
+                    git_params: None,
+                    icon_path: None,
+                },
+            },
+        )
+        .await
+        .unwrap()
+        .id;
+
+    // Check that the collection is initially not archived
+    let (events, _stream_output) = test_stream_collections(&ctx, &workspace).await;
+    assert!(!events.get(&id).unwrap().archived);
+
+    workspace
+        .archive_collection(&ctx, ArchiveCollectionInput { id: id.clone() })
+        .await
+        .unwrap();
+
+    // Check that collection is flagged as archived during streaming
+    let (events, _stream_output) = test_stream_collections(&ctx, &workspace).await;
+
+    assert_eq!(events.len(), 1);
+    assert!(events.get(&id).unwrap().archived);
+
+    cleanup().await;
+}
+
+#[tokio::test]
+pub async fn archive_collection_already_archived() {
+    let (ctx, _, workspace, cleanup) = setup_test_workspace().await;
+
+    let collection_name = random_collection_name();
+    let id = workspace
+        .create_collection(
+            &ctx,
+            &CreateCollectionInput {
+                inner: CreateCollectionParams {
+                    name: collection_name.clone(),
+                    order: 0,
+                    external_path: None,
+                    git_params: None,
+                    icon_path: None,
+                },
+            },
+        )
+        .await
+        .unwrap()
+        .id;
+
+    workspace
+        .archive_collection(&ctx, ArchiveCollectionInput { id: id.clone() })
+        .await
+        .unwrap();
+
+    let result = workspace
+        .archive_collection(&ctx, ArchiveCollectionInput { id: id.clone() })
+        .await;
+    assert!(result.is_ok());
+
+    // Check that collection is still flagged as archived during streaming
+    let (events, _stream_output) = test_stream_collections(&ctx, &workspace).await;
+
+    assert_eq!(events.len(), 1);
+    assert!(events.get(&id).unwrap().archived);
+
+    cleanup().await;
+}
+
+#[tokio::test]
+pub async fn archived_collection_nonexistent() {
+    let (ctx, _, workspace, cleanup) = setup_test_workspace().await;
+
+    let result = workspace
+        .archive_collection(
+            &ctx,
+            ArchiveCollectionInput {
+                id: CollectionId::new(),
+            },
+        )
+        .await;
+
+    assert!(result.is_err());
+
+    cleanup().await;
+}

--- a/crates/moss-workspace/tests/workspace__unarchive_collection.rs
+++ b/crates/moss-workspace/tests/workspace__unarchive_collection.rs
@@ -1,0 +1,111 @@
+#![cfg(feature = "integration-tests")]
+
+use moss_testutils::random_name::random_collection_name;
+use moss_workspace::models::{
+    operations::{ArchiveCollectionInput, CreateCollectionInput, UnarchiveCollectionInput},
+    primitives::CollectionId,
+    types::CreateCollectionParams,
+};
+
+use crate::shared::{setup_test_workspace, test_stream_collections};
+
+pub mod shared;
+
+#[tokio::test]
+pub async fn unarchive_collection_success() {
+    let (ctx, _, workspace, cleanup) = setup_test_workspace().await;
+
+    let collection_name = random_collection_name();
+    let id = workspace
+        .create_collection(
+            &ctx,
+            &CreateCollectionInput {
+                inner: CreateCollectionParams {
+                    name: collection_name.clone(),
+                    order: 0,
+                    external_path: None,
+                    git_params: None,
+                    icon_path: None,
+                },
+            },
+        )
+        .await
+        .unwrap()
+        .id;
+
+    // First archive the collection and unarchive it
+    workspace
+        .archive_collection(&ctx, ArchiveCollectionInput { id: id.clone() })
+        .await
+        .unwrap();
+
+    workspace
+        .unarchive_collection(&ctx, UnarchiveCollectionInput { id: id.clone() })
+        .await
+        .unwrap();
+
+    // Check that the collection is now unarchived
+    // Check that collection is flagged as archived during streaming
+    let (events, _stream_output) = test_stream_collections(&ctx, &workspace).await;
+
+    assert_eq!(events.len(), 1);
+    assert!(!events.get(&id).unwrap().archived);
+
+    cleanup().await;
+}
+
+#[tokio::test]
+pub async fn unarchive_collection_already_unarchived() {
+    let (ctx, _, workspace, cleanup) = setup_test_workspace().await;
+    let collection_name = random_collection_name();
+    let id = workspace
+        .create_collection(
+            &ctx,
+            &CreateCollectionInput {
+                inner: CreateCollectionParams {
+                    name: collection_name.clone(),
+                    order: 0,
+                    external_path: None,
+                    git_params: None,
+                    icon_path: None,
+                },
+            },
+        )
+        .await
+        .unwrap()
+        .id;
+
+    // Check that the collection is already unarchived
+    let (events, _stream_output) = test_stream_collections(&ctx, &workspace).await;
+    assert!(!events.get(&id).unwrap().archived);
+
+    let result = workspace
+        .unarchive_collection(&ctx, UnarchiveCollectionInput { id: id.clone() })
+        .await;
+    assert!(result.is_ok());
+
+    // Check that collection is still unarchived
+    let (events, _stream_output) = test_stream_collections(&ctx, &workspace).await;
+
+    assert_eq!(events.len(), 1);
+    assert!(!events.get(&id).unwrap().archived);
+
+    cleanup().await;
+}
+
+#[tokio::test]
+pub async fn unarchived_collection_nonexistent() {
+    let (ctx, _, workspace, cleanup) = setup_test_workspace().await;
+    let result = workspace
+        .unarchive_collection(
+            &ctx,
+            UnarchiveCollectionInput {
+                id: CollectionId::new(),
+            },
+        )
+        .await;
+
+    assert!(result.is_err());
+
+    cleanup().await;
+}

--- a/view/desktop/bin/src/commands/workspace.rs
+++ b/view/desktop/bin/src/commands/workspace.rs
@@ -148,6 +148,36 @@ pub async fn update_collection<'a, R: tauri::Runtime>(
 
 #[tauri::command(async)]
 #[instrument(level = "trace", skip(app), fields(window = window.label()))]
+pub async fn archive_collection<'a, R: tauri::Runtime>(
+    ctx: State<'_, moss_applib::context::AsyncContext>,
+    app: App<'a, R>,
+    window: Window<R>,
+    input: ArchiveCollectionInput,
+    options: Options,
+) -> TauriResult<ArchiveCollectionOutput> {
+    super::with_workspace_timeout(ctx.inner(), app, options, |ctx, _, workspace| async move {
+        workspace.archive_collection(&ctx, input).await
+    })
+    .await
+}
+
+#[tauri::command(async)]
+#[instrument(level = "trace", skip(app), fields(window = window.label()))]
+pub async fn unarchive_collection<'a, R: tauri::Runtime>(
+    ctx: State<'_, moss_applib::context::AsyncContext>,
+    app: App<'a, R>,
+    window: Window<R>,
+    input: UnarchiveCollectionInput,
+    options: Options,
+) -> TauriResult<UnarchiveCollectionOutput> {
+    super::with_workspace_timeout(ctx.inner(), app, options, |ctx, _, workspace| async move {
+        workspace.unarchive_collection(&ctx, input).await
+    })
+    .await
+}
+
+#[tauri::command(async)]
+#[instrument(level = "trace", skip(app), fields(window = window.label()))]
 pub async fn batch_update_collection<'a, R: tauri::Runtime>(
     ctx: State<'_, moss_applib::context::AsyncContext>,
     app: App<'a, R>,

--- a/view/desktop/bin/src/lib.rs
+++ b/view/desktop/bin/src/lib.rs
@@ -176,6 +176,8 @@ pub async fn run<R: TauriRuntime>() {
             commands::import_collection,
             commands::delete_collection,
             commands::update_collection,
+            commands::archive_collection,
+            commands::unarchive_collection,
             commands::batch_update_collection,
             commands::activate_environment,
             commands::create_environment,

--- a/view/desktop/src/lib/backend/tauri.ts
+++ b/view/desktop/src/lib/backend/tauri.ts
@@ -33,6 +33,8 @@ export type TauriIpcCommand =
   | "delete_collection"
   | "stream_collections"
   | "update_collection"
+  | "archive_collection"
+  | "unarchive_collection"
   | "batch_update_collection"
   | "stream_environments"
   | "create_environment"


### PR DESCRIPTION
Introduce a field `archived` in the collection local config file. When restoring an archived collection, its worktree and vcs will not be loaded: however, its worktree can still be reloaded when calling `stream_collection_entries`, to allow the user to still see the structure and content of an archived collection. This field is also present in `StreamCollectionsEvent` for the frontend.
Right now, archiving a collection will not drop its worktree and vcs, nor would unarchiving a collection restore its vcs. We can implement them later if they make sense.
