### PR TITLE
refactor(SAPIC-536): Remove feature declarations from the workspace level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ async-stream = "0.3.6"
 notify = "8.0"
 redb = "2.6.0"
 tauri = { version = "2.2.5", default-features = false }
-rand = { version = "0.9.0", features = ["thread_rng"] }
+rand = { version = "0.9.0", default-features = false}
 serde = "1.0.217"
 anyhow = "1.0.95"
 arcstr = "1.2.0"
@@ -114,22 +114,22 @@ dashmap = "6.1.0"
 async-trait = "0.1.86"
 url = "2.5.4"
 dotenv = "0.15.0"
-keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
+keyring = "3"
 whoami = "1.5.2"
-chrono = { version = "0.4.40", features = ["now"] }
+chrono = { version = "0.4.40", default-features = false }
 webbrowser = "1.0.3"
-zeroize = { version = "1.7", features = ["zeroize_derive"] }
+zeroize = { version = "1.7" }
 aes-gcm = "0.10.3"
 argon2 = "0.5.1"
 validator = "0.20.0"
 futures = "0.3.31"
-regex = { version = "1.11.1", default-features = false, features = [] }
+regex = { version = "1.11.1", default-features = false }
 smallvec = "1.15.0"
 toml_edit = "0.22"
 nanoid = "0.4.0"
 rustc-hash = "2.1.1"
 derive_more = "2.0.1"
-image = { version = "0.25.6", default-features = false, features = ["png"]}
+image = { version = "0.25.6", default-features = false}
 hcl-rs = "0.18.5"
 indexmap = "2.9.0"
 wasmtime = "34.0.2"
@@ -142,8 +142,8 @@ urlencoding = "2.1.3"
 tokio-util = "0.7.12"
 proc-macro2 = "1.0.101"
 quote = "1.0.40"
-syn = {version = "2.0.106", features = ["full"]}
-async_zip = {version = "0.0.18", default-features = false, features = ["deflate", "tokio", "tokio-fs", "tokio-util"]}
+syn = {version = "2.0.106"}
+async_zip = {version = "0.0.18", default-features = false}
 
 [profile.release]
 opt-level = 3 # Maximize performance

--- a/crates/moss-bindingutils/macro/Cargo.toml
+++ b/crates/moss-bindingutils/macro/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2024"
 proc-macro = true
 
 [dependencies]
-syn.workspace = true
+syn = { workspace = true, features = ["full"] }
 quote.workspace = true

--- a/crates/moss-fs/Cargo.toml
+++ b/crates/moss-fs/Cargo.toml
@@ -19,7 +19,7 @@ tokio-stream.workspace = true
 tauri.workspace = true
 derive_more.workspace = true
 thiserror.workspace = true
-async_zip.workspace = true
+async_zip = { workspace = true, features = ["deflate", "tokio", "tokio-fs", "tokio-util"] }
 tokio-util.workspace = true
 nanoid.workspace = true
 

--- a/crates/moss-id-macro/Cargo.toml
+++ b/crates/moss-id-macro/Cargo.toml
@@ -9,4 +9,4 @@ proc-macro = true
 [dependencies]
 proc-macro2.workspace = true
 quote.workspace = true
-syn.workspace = true
+syn = { workspace = true, features = ["full"] }

--- a/crates/moss-keyring/Cargo.toml
+++ b/crates/moss-keyring/Cargo.toml
@@ -8,7 +8,7 @@ moss_logging.workspace = true
 
 tracing.workspace = true
 keyring = { workspace = true, features = ["apple-native", "windows-native", "sync-secret-service"] }
-zeroize = { workspace = true }
+zeroize = { workspace = true, features = ["zeroize_derive"] }
 whoami.workspace = true
 joinerror.workspace = true
 async-trait.workspace = true

--- a/crates/moss-project/Cargo.toml
+++ b/crates/moss-project/Cargo.toml
@@ -34,7 +34,7 @@ serde_json.workspace = true
 validator = { workspace = true, features = ["derive"] }
 tauri.workspace = true
 futures.workspace = true
-image.workspace = true
+image = { workspace = true, features = ["png"] }
 hcl-rs.workspace = true
 derive_more = { workspace = true, features = ["deref", "deref_mut"] }
 indexmap.workspace = true

--- a/crates/moss-testutils/Cargo.toml
+++ b/crates/moss-testutils/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-rand.workspace = true
+rand = { workspace = true, features = ["thread_rng"] }
 
 [features]
 integration-tests = []

--- a/crates/moss-workspace/Cargo.toml
+++ b/crates/moss-workspace/Cargo.toml
@@ -32,8 +32,8 @@ tauri.workspace = true
 serde_json.workspace = true
 futures.workspace = true
 derive_more = { workspace = true, features = ["deref", "deref_mut"] }
-image.workspace = true
-rand.workspace = true
+image = { workspace = true, features = ["png"] }
+rand = { workspace = true, features = ["thread_rng"] }
 async-trait.workspace = true
 async-stream.workspace = true
 nanoid.workspace = true


### PR DESCRIPTION
Remove feature declarations from the workspace level for more conscious usage of features, since it's easier to tell on a crate level which features are actually used, compared to when they are all declared together at the top level. Plus, features declared at the top cannot be overridden, which might introduce some subtle issues.