### PR TITLE
feat(SAPIC-552): PoC for implementing and using keybindings

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -448,6 +448,9 @@ importers:
       react-scan:
         specifier: ^0.4.3
         version: 0.4.3(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.45.1)
+      rooks:
+        specifier: ^9.3.0
+        version: 9.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       simplebar:
         specifier: ^6.3.2
         version: 6.3.2
@@ -3536,6 +3539,9 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  performance-now@2.1.0:
+    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -3675,6 +3681,9 @@ packages:
   raf-schd@4.0.3:
     resolution: {integrity: sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==}
 
+  raf@3.4.1:
+    resolution: {integrity: sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==}
+
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
@@ -3799,6 +3808,13 @@ packages:
     resolution: {integrity: sha512-4iya7Jb76fVpQyLoiVpzUrsjQ12r3dM7fIVz+4NwoYvZOShknRmiv+iu9CClZml5ZLGb0XMcYLutK6w9tgxHDw==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  rooks@9.3.0:
+    resolution: {integrity: sha512-ez9ReItW+a/GXsA92Lfh5KWTjhbzlp354KOlC5oh9RHVD5fs/GaWwBq72F2xkDXVblgCgFs0Nel1hxojtszhgw==}
+    engines: {node: '>=v10.24.1'}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
 
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
@@ -7372,6 +7388,8 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  performance-now@2.1.0: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -7436,6 +7454,10 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   raf-schd@4.0.3: {}
+
+  raf@3.4.1:
+    dependencies:
+      performance-now: 2.1.0
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:
@@ -7575,6 +7597,15 @@ snapshots:
       '@rollup/rollup-win32-ia32-msvc': 4.45.1
       '@rollup/rollup-win32-x64-msvc': 4.45.1
       fsevents: 2.3.3
+
+  rooks@9.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      fast-deep-equal: 3.1.3
+      lodash.debounce: 4.0.8
+      raf: 3.4.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      use-sync-external-store: 1.5.0(react@18.3.1)
 
   rrweb-cssom@0.8.0: {}
 

--- a/view/desktop/bin/src/lib.rs
+++ b/view/desktop/bin/src/lib.rs
@@ -153,7 +153,7 @@ pub async fn run<R: TauriRuntime>() {
                 let ctx_clone = ctx.clone();
                 let (app, session_id) = {
                     let shortcut_println_command =
-                        CommandDecl::<R>::new("shortcut.println".into(), |ctx| {
+                        CommandDecl::<R>::new("shortcut.println".into(), |_ctx| {
                             Box::pin(async move {
                                 println!("Triggering println using shortcut");
                                 Ok(Value::Null)

--- a/view/desktop/package.json
+++ b/view/desktop/package.json
@@ -57,7 +57,8 @@
     "simplebar-react": "^3.3.2",
     "sonner": "^2.0.7",
     "zod": "^3.24.4",
-    "zustand": "^5.0.3"
+    "zustand": "^5.0.3",
+    "rooks": "^9.3.0"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/view/desktop/src/pages/LogsPage/LogsPage.tsx
+++ b/view/desktop/src/pages/LogsPage/LogsPage.tsx
@@ -112,7 +112,7 @@ export const Logs = () => {
   return (
     <PageContent className="space-y-6">
       <section className="mb-6">
-        <h2 className="mb-2 text-xl">File Statuses</h2>
+        <h2 className="mb-2 text-xl">Shortcut Demo</h2>
         <div className="rounded bg-gray-50 p-4">
           <Shortcut />
         </div>

--- a/view/desktop/src/pages/LogsPage/LogsPage.tsx
+++ b/view/desktop/src/pages/LogsPage/LogsPage.tsx
@@ -9,6 +9,7 @@ import GitTest from "@/git/GitTest.tsx";
 import { AddAccountParams, LogEntryInfo, ON_DID_APPEND_LOG_ENTRY_CHANNEL, UpdateProfileInput } from "@repo/moss-app";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import Shortcut from "@/shortcut/Shortcut.tsx";
 
 interface CreateProfileData {
   name: string;
@@ -110,6 +111,13 @@ export const Logs = () => {
 
   return (
     <PageContent className="space-y-6">
+      <section className="mb-6">
+        <h2 className="mb-2 text-xl">File Statuses</h2>
+        <div className="rounded bg-gray-50 p-4">
+          <Shortcut />
+        </div>
+      </section>
+
       <section className="mb-6">
         <h2 className="mb-2 text-xl">File Statuses</h2>
         <div className="rounded bg-gray-50 p-4">

--- a/view/desktop/src/shortcut/Shortcut.tsx
+++ b/view/desktop/src/shortcut/Shortcut.tsx
@@ -1,0 +1,55 @@
+import { useKeys } from "rooks";
+import { platform } from "@tauri-apps/plugin-os";
+import { useEffect } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { invoke } from "@tauri-apps/api/core";
+
+type ShortcutDecl = {
+  name: string;
+  macos: string[];
+  all: string[];
+};
+
+const shortcuts: ShortcutDecl[] = [
+  {
+    name: "println",
+    macos: ["Meta", "KeyP"],
+    all: ["Control", "KeyP"],
+  },
+  {
+    name: "alert",
+    macos: ["Meta", "KeyA"],
+    all: ["Control", "KeyA"],
+  },
+];
+
+const Shortcut = () => {
+  useEffect(() => {
+    const unlisten = listen("alert", (_event) => {
+      alert("Triggering alert using shortcut");
+    });
+
+    return () => {
+      unlisten.then((f) => f());
+    };
+  }, []);
+
+  const currentPlatform = platform();
+
+  for (const decl of shortcuts) {
+    const keys = currentPlatform == "macos" ? decl.macos : decl.all;
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useKeys(keys, (_event) => {
+      const commandName = `shortcut.${decl.name}`;
+      console.log(`Executing command '${commandName}'`);
+      invoke("execute_command", {
+        cmd: commandName,
+        args: {},
+      }).then(() => console.log("Shortcut triggered"));
+    });
+  }
+
+  return <></>;
+};
+
+export default Shortcut;

--- a/view/desktop/src/shortcut/Shortcut.tsx
+++ b/view/desktop/src/shortcut/Shortcut.tsx
@@ -7,19 +7,19 @@ import { invoke } from "@tauri-apps/api/core";
 type ShortcutDecl = {
   name: string;
   macos: string[];
-  all: string[];
+  default: string[];
 };
 
 const shortcuts: ShortcutDecl[] = [
   {
     name: "println",
     macos: ["Meta", "KeyP"],
-    all: ["Control", "KeyP"],
+    default: ["Control", "KeyP"],
   },
   {
     name: "alert",
     macos: ["Meta", "KeyA"],
-    all: ["Control", "KeyA"],
+    default: ["Control", "KeyA"],
   },
 ];
 
@@ -37,7 +37,7 @@ const Shortcut = () => {
   const currentPlatform = platform();
 
   for (const decl of shortcuts) {
-    const keys = currentPlatform == "macos" ? decl.macos : decl.all;
+    const keys = currentPlatform == "macos" ? decl.macos : decl.default;
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useKeys(keys, (_event) => {
       const commandName = `shortcut.${decl.name}`;


### PR DESCRIPTION
Implement shortcut mechanism through frontend listener + application command. The demo contains two shortcuts (Replace Ctrl with Command on MacOS):
Ctrl + A: create an alert popup
Ctrl + P: print out a message in Rust console
This is achieved by `invoke("execute_command")` when a shortcut is pressed. If the command needs to do something on the frontend (like alert in this example), it can emit an event to the frontend. 
To test it, open the LogsPage since the listeners are registered on the component there